### PR TITLE
ENH: If a ufunc reduces frame to 0-d, return scalar. Needed for ndimage.

### DIFF
--- a/pims/frame.py
+++ b/pims/frame.py
@@ -16,6 +16,10 @@ class Frame(ndarray):
         self.metadata = getattr(obj, 'metadata', None)
 
     def __array_wrap__(self, out_arr, context=None):
+        # Handle scalars so as not to break ndimage.
+        # See http://stackoverflow.com/a/794812/1221924
+        if out_arr.size == 1:
+            return out_arr[()]  
         return ndarray.__array_wrap__(self, out_arr, context)
 
     def __reduce__(self):


### PR DESCRIPTION
Happy Saturday. I weirdly couldn't sleep past the daylight, so I threw together a [proof-of-concept example notebook](http://nbviewer.ipython.org/github/danielballan/trackpy/blob/parallel/examples/parallel-locate.ipynb) using IPython.parallel and locate. It requires this fix before I merge.

Before:

```
In [4]: image.sum()
Out[4]: Frame(34423137L, dtype=uint64)

In [5]: ndimage.center_of_mass(image)
TypeError: 'numpy.float64' object is not iterable
```

After:

```
In [4]: image.sum()
Out[4]: 34423137

In [5]: ndimage.center_of_mass(image)
Out[5]: (211.53404859644257, 318.25055525880748)
```

I couldn't find any implementations of this kind of scalar reduction online, so I invented one that seems reasonable. (In this case pandas Series v < 0.13 is not analogous: all the ufuncs were rewritten to be index- and NA-aware.)

Also, in a gesture of diligence that eluded me on Friday afternoon, all trackpy tests pass using this pims branch.
