### PR TITLE
CLN/API: ImageSequence subclasses FramesSequence; invert, gray remove

### DIFF
--- a/pims/tests/test_video.py
+++ b/pims/tests/test_video.py
@@ -64,12 +64,9 @@ class _base_klass(unittest.TestCase):
 class _frame_base_klass(_base_klass):
     def test_iterator(self):
         self.check_skip()
-        assert_equal(self.v.next(), self.frame0)
-        assert_equal(self.v.next(), self.frame1)
-
-    def test_rewind(self):
-        self.v.rewind()
-        assert_equal(self.v.next(), self.frame0)
+        i = iter(self.v)
+        assert_equal(i.next(), self.frame0)
+        assert_equal(i.next(), self.frame1)
 
 
 class TestVideo(_frame_base_klass):
@@ -117,7 +114,7 @@ class TestImageSequence(_frame_base_klass):
         self.filename = os.path.join(path, 'image_sequence')
         self.frame0 = np.load(os.path.join(path, 'seq_frame0.npy'))
         self.frame1 = np.load(os.path.join(path, 'seq_frame1.npy'))
-        self.v = pims.ImageSequence(self.filename, invert=False)
+        self.v = pims.ImageSequence(self.filename)
 
     def test_shape(self):
         assert_equal(self.v.frame_shape, (424, 640))

--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -44,7 +44,7 @@ class TiffStack_libtiff(FramesSequence):
     ...    # Do something with frames 5, 7, and 13.
 
     >>> frame_count = video.count # Number of frames in video
-    >>> frame_shape = video.shape # Pixel dimensions of video
+    >>> frame_shape = video.frame_shape # Pixel dimensions of video
     """
     def __init__(self, filename, dtype=None):
         self._filename = filename


### PR DESCRIPTION
- In lieu of `invert` and `gray`, `ImageSequence` accepts `process_func`. Ultimately, perhaps the validation logic could move into the superclass.
- `ImageSequence` has no `__next__` method; you have to do
  
  ```
  i = iter(ImageSequence('dir'))
  next(i)
  ```

which is less confusing anyway
- ImageSequence accepts a dype arg, following TiffStack classes. Possibly some of this logic could move into the superclass as well.
