### PR TITLE
BUG: Switch to mpl's imread which handles PIL weirdness.

### DIFF
--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -1,6 +1,6 @@
 import os
 import subprocess as sp
-from scipy.ndimage import imread
+from matplotlib.pyplot import imread
 from pims.base_frames import FramesSequence
 
 


### PR DESCRIPTION
Before:

```
In [2]: a = pims.ImageSequence('.')[0]
Out[2]: 
array(<PIL.TiffImagePlugin.TiffImageFile image mode=I;16B size=1392x1040 at 0xB7330A0C>, dtype=object)
```

After:

```
In [2]: a = pims.ImageSequence('.')[0]
Out[2]: 
array([[115, 117, 118, ..., 124, 123, 126],
   [118, 115, 117, ..., 126, 127, 123],
   [112, 116, 114, ..., 125, 124, 123],
   ..., 
   [104, 105, 108, ..., 110, 109, 112],
   [104, 106, 106, ..., 112, 113, 112],
   [106, 106, 106, ..., 113, 113, 113]], dtype=uint16)
```
