### PR TITLE
ENH: Match pathname pattern to avoid extraneous files.

### DIFF
--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -1,5 +1,6 @@
 import os
-import subprocess as sp
+import glob
+from warnings import warn
 from scipy.ndimage import imread as scipy_imread
 from matplotlib.pyplot import imread as mpl_imread
 from pims.base_frames import FramesSequence
@@ -11,13 +12,15 @@ class ImageSequence(FramesSequence):
 
     Parameters
     ----------
-    directory : string
+    pathname : string
+       a directory or, safer, a pattern like path/to/images/*.png
+       which will ignore extraneous files
     gray : Convert color image to grayscale. True by default.
     invert : Invert black and white. True by default.
 
     Examples
     --------
-    >>> video = ImageSequence('directory_name')
+    >>> video = ImageSequence('path/to/images/*.png')  # or *.tif, or *.jpg
     >>> imshow(video[0]) # Show the first frame.
     >>> imshow(video[1][0:10][0:10]) # Show one corner of the second frame.
 
@@ -34,15 +37,20 @@ class ImageSequence(FramesSequence):
     >>> frame_shape = video.frame_shape # Pixel dimensions of video
     """
 
-    def __init__(self, directory, process_func=None, dtype=None):
-        if not os.path.isdir(directory):
-            raise ValueError("%s is not a directory." % directory)
-        self.directory = os.path.abspath(directory)
-        filenames = os.listdir(directory)
-        filenames.sort()  # listdir returns arbitrary order
-        make_full_path = lambda filename: (
-            os.path.abspath(os.path.join(directory, filename)))
-        self._filepaths = map(make_full_path, filenames)
+    def __init__(self, pathname, process_func=None, dtype=None):
+        if os.path.isdir(pathname):
+            warn("Loading ALL files in this directory. To ignore extraneous "
+                 "files, use a pattern like 'path/to/images/*.png'",
+                 UserWarning)
+            directory = pathname
+            filenames = os.listdir(directory)
+            make_full_path = lambda filename: (
+                os.path.abspath(os.path.join(directory, filename)))
+            filepaths = map(make_full_path, filenames)
+        else:
+            filepaths = glob.glob(pathname)
+        filepaths.sort()  # listdir returns arbitrary order
+        self._filepaths = filepaths
         self._count = len(self._filepaths)
 
         if process_func is None:
@@ -86,20 +94,3 @@ class ImageSequence(FramesSequence):
     @property
     def pixel_type(self):
         return self._dtype
-
-    def play(self):
-        try:
-            from IPython.core.display import HTML
-        except ImportError:
-            raise ImportError("This function requires IPython and should "
-                              "be run in an IPython notebook.")
-        cmd = ("cat {0}/* | ffmpeg -r 24 -y -f image2pipe -c:v png -i - "
-               "-c:v libx264 -preset ultrafast -qp 0 -movflags +faststart "
-               "-pix_fmt yuv420p -f matroska  -".format(self.directory))
-        process = sp.Popen(cmd, shell=True, 
-                           stdin=sp.PIPE, stdout=sp.PIPE, stderr=sp.PIPE)
-        video_binary = process.stdout.read()
-        video_base64 = video_binary.encode("base64")
-        source = 'data:video/x-m4v;base64,{0}'.format(video_base64)
-        video_tag = '<video controls alt="test" src="{0}">'.format(source)
-        return HTML(data=video_tag)


### PR DESCRIPTION
@tacaswell I pounced on this because I've been meaning to incorporate `glob` for awhile.

`ImageSequence('path/to/images/*.png')` is now the preferred usage. If you specify a directory without a filename pattern, ImageSequence will work the same way as before. But it warns that this could pick up extraneous files.

@RebeccaWPerry, I think it this more sound than skipping over unreadable files as you go. ImageSequence needs to start with an accurate count of the number of images, so it can do fancy indexing. This is also more like the way it's done over at scikit-image.
