### PR TITLE
If C compiling fails, restart setup without extensions.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,7 +66,7 @@ write_version_py()
 def read(fname):
     return open(os.path.join(os.path.dirname(__file__), fname)).read()
 
-setup(
+setup_parameters = dict(
     name="pims",
     version=FULLVERSION,
     description="Python Image Sequence",
@@ -75,5 +75,14 @@ setup(
     author="Daniel Allan",
     author_email="dallan@pha.jhu.edu",
     url="https://github.com/soft-matter/pims",
-    packages=['pims'],
-)
+    packages=['pims'])
+
+try:
+    setup(**setup_parameters)
+except SystemExit:
+    warnings.warn(
+        """DON'T PANIC! Compiling C is not working, so I will 
+skip the components that need a C compiler.""")
+    # Try again without ext_modules.
+    del setup_parameters['ext_modules']
+    setup(**setup_parameters))


### PR DESCRIPTION
This should make pims installable on systems with a working C compiler (Windows, old Macs where Xcode is a pain to obtain...).

Before merging: Will pims be importable if the fall-back `setup_parameters`?
