### PR TITLE
ENH: Add nice repr for all classes.

### DIFF
--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -75,6 +75,14 @@ class FramesStream(with_metaclass(ABCMeta, object)):
     def __exit__(self, exc_type, exc_value, traceback):
         self.close()
 
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Frame Shape: {w} x {h}
+Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  dtype=self.pixel_type)
+
 
 class FramesSequence(FramesStream):
     """Baseclass for wrapping data buckets that have random access.
@@ -131,6 +139,16 @@ class FramesSequence(FramesStream):
         nonsense should be dealt with in this function.
         """
         pass
+
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Length: {count} frames
+Frame Shape: {w} x {h}
+Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  count = len(self),
+                                  dtype=self.pixel_type)
 
 
 class FrameRewindableStream(FramesStream):
@@ -229,6 +247,16 @@ class FrameRewindableStream(FramesStream):
             self.skip_forward(step - 1)
         else:
             raise StopIteration
+
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Length: {count} frames
+Frame Shape: {w} x {h}
+Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  count = len(self),
+                                  dtype=self.pixel_type)
 
 
 class BaseFrames(FramesSequence):

--- a/pims/ffmpeg_reader.py
+++ b/pims/ffmpeg_reader.py
@@ -197,3 +197,15 @@ class FFmpegVideoReader(FramesSequence):
     @property
     def pixel_type(self):
         raise NotImplemented()
+
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Source: {filename}
+Length: {count} frames
+Frame Shape: {w} x {h}
+Pixel Format: {pix_fmt}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  count=len(self),
+                                  filename=self.filename,
+                                  pix_fmt=self.pix_fmt)

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -43,6 +43,7 @@ class ImageSequence(FramesSequence):
     """
 
     def __init__(self, pathname, process_func=None, dtype=None):
+        self.pathname = os.path.abspath(pathname)  # used by __repr__
         if os.path.isdir(pathname):
             warn("Loading ALL files in this directory. To ignore extraneous "
                  "files, use a pattern like 'path/to/images/*.png'",
@@ -99,3 +100,15 @@ class ImageSequence(FramesSequence):
     @property
     def pixel_type(self):
         return self._dtype
+
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Source: {pathname}
+Length: {count} frames
+Frame Shape: {w} x {h}
+Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  count=len(self),
+                                  pathname=self.pathname,
+                                  dtype=self.pixel_type)

--- a/pims/tests/test_video.py
+++ b/pims/tests/test_video.py
@@ -67,6 +67,10 @@ class _base_klass(unittest.TestCase):
         self.v[-1]
         list(self.v[[0, -1]])
 
+    def test_repr(self):
+        # simple smoke test, values not checked
+        repr(self.v)
+
 
 class _frame_base_klass(_base_klass):
     def test_iterator(self):

--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -85,6 +85,18 @@ class TiffStack_tifffile(FramesSequence):
     def __len__(self):
         return len(self._tiff)
 
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Source: {filename}
+Length: {count} frames
+Frame Shape: {w} x {h}
+Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  count=len(self),
+                                  filename=self._filename,
+                                  dtype=self.pixel_type)
+
 
 class TiffStack_libtiff(FramesSequence):
     """Iterable object that returns frames of video as numpy arrays.
@@ -158,6 +170,18 @@ class TiffStack_libtiff(FramesSequence):
     def __len__(self):
         return self._count
 
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Source: {filename}
+Length: {count} frames
+Frame Shape: {w} x {h}
+Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  count=len(self),
+                                  filename=self._filename,
+                                  dtype=self.pixel_type)
+
 
 class TiffStack_pil(FramesSequence):
     '''
@@ -176,6 +200,7 @@ class TiffStack_pil(FramesSequence):
     def __init__(self, fname, dtype=None):
 
         self.im = Image.open(fname)
+        self._filename = fname  # used by __repr__
 
         self.im.seek(0)
         # this will need some work to deal with color
@@ -232,6 +257,19 @@ class TiffStack_pil(FramesSequence):
 
     def close(self):
         self._tiff.close()
+
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Source: {filename}
+Length: {count} frames
+Frame Shape: {w} x {h}
+Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  count=len(self),
+                                  filename=self._filename,
+                                  dtype=self.pixel_type)
+
 
 
 class MM_TiffStack(TiffStack_pil):
@@ -323,6 +361,20 @@ class TiffSeries(FramesSequence):
 
     def __len__(self):
         return self._count
+
+    def __repr__(self):
+        # May be overwritten by subclasses
+        return """<Frames>
+Source: {name_template}
+Length: {count} frames
+Frame Shape: {w} x {h}
+Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
+                                  h=self.frame_shape[1],
+                                  count=len(self),
+                                  name_template=self._name_template,
+                                  dtype=self.pixel_type)
+
+
 
 
 # needed for the wrapper classes


### PR DESCRIPTION
This restores behaviors from `mr` where Frames classes display useful info. Example:

```
In [4]: v = pims.ImageSequence('/Users/danielallan/image_seq_example/*.jpg')

In [5]: v
Out[5]: 
<Frames>
Source: /Users/danielallan/image_seq_example/*.jpg
Length: 12 frames
Frame Shape: 512 x 512
Pixel Datatype: uint8
```

I wrote a separate `__repr__` for each class. There is some repeated code, to be sure, but each class should be free to display any info pertinent to its own idiosyncrasies. (And all the base classes have a `__repr__` in case user-defined subclasses do not define their own `__repr__`.)

A very basic test confirms that, for every class, `repr(v)` runs without erroring.
