### PR TITLE
ENH: Add convenient greyscale conversion.

### DIFF
--- a/pims/ffmpeg_reader.py
+++ b/pims/ffmpeg_reader.py
@@ -90,9 +90,45 @@ _pix_fmt_dict = {'rgb24': 3,
 
 
 class FFmpegVideoReader(FramesSequence):
+    """Read images from the frames of a standard video file into an
+    iterable object that returns images as numpy arrays.
 
+    This reader, based on tiffile.py, should read standard TIFF 
+    files and sundry derivatives of the format used in microscopy.
+
+    Parameters
+    ----------
+    filename : string
+    process_func : function, optional
+        callable with signalture `proc_img = process_func(img)`,
+        which will be applied to the data from each frame
+    dtype : numpy datatype, optional
+        Image arrays will be converted to this datatype.
+    as_grey : boolean, optional
+        Convert color images to greyscale. False by default.
+        May not be used in conjection with process_func.
+
+    Examples
+    --------
+    >>> video = FFmpegVideoReader('video.avi')  # or .mov, etc.
+    >>> imshow(video[0]) # Show the first frame.
+    >>> imshow(video[-1]) # Show the last frame.
+    >>> imshow(video[1][0:10, 0:10]) # Show one corner of the second frame.
+
+    >>> for frame in video[:]:
+    ...    # Do something with every frame.
+
+    >>> for frame in video[10:20]:
+    ...    # Do something with frames 10-20.
+
+    >>> for frame in video[[5, 7, 13]]:
+    ...    # Do something with frames 5, 7, and 13.
+
+    >>> frame_count = len(video) # Number of frames in video
+    >>> frame_shape = video.frame_shape # Pixel dimensions of video
+    """
     def __init__(self, filename, process_func=None, pix_fmt="rgb24",
-                 use_cache=True):
+                 use_cache=True, as_grey=False):
 
         self.filename = filename
         self.pix_fmt = pix_fmt
@@ -105,6 +141,7 @@ class FFmpegVideoReader(FramesSequence):
         self._stride = self.depth*w*h
 
         self._validate_process_func(process_func)
+        self._as_grey(as_grey, process_func)
 
     def _initialize(self, use_cache):
         """ Opens the file, creates the pipe. """

--- a/pims/tests/test_video.py
+++ b/pims/tests/test_video.py
@@ -64,24 +64,29 @@ class _base_klass(unittest.TestCase):
         self.assertTrue(isinstance(len(self.v), int))
 
     def test_simple_negative_index(self):
+        self.check_skip()
         self.v[-1]
         list(self.v[[0, -1]])
 
     def test_repr(self):
+        self.check_skip()
         # simple smoke test, values not checked
         repr(self.v)
 
     def test_frame_number_present(self):
+        self.check_skip()
         for frame_no in [0, 1, 2, 1]:
             self.assertTrue(hasattr(self.v[frame_no], 'frame_no'))
             not_none = self.v[frame_no].frame_no is not None
             self.assertTrue(not_none)
 
     def test_frame_number_accurate(self):
+        self.check_skip()
         for frame_no in [0, 1, 2, 1]:
             self.assertEqual(self.v[frame_no].frame_no, frame_no)
 
     def test_process_func(self):
+        self.check_skip()
         # Use a trivial identity function to verify the process_func exists.
         f = lambda x: x
         self.klass(self.filename, process_func=f, **self.kwargs)
@@ -91,6 +96,7 @@ class _base_klass(unittest.TestCase):
         self.klass(self.filename, f, **self.kwargs)
 
     def test_inversion_process_func(self):
+        self.check_skip()
         def invert(image):
             max_value = np.iinfo(image.dtype).max
             image = image ^ max_value
@@ -100,19 +106,25 @@ class _base_klass(unittest.TestCase):
         v = self.klass(self.filename, invert, **self.kwargs)
         assert_equal(v[0], invert(v_raw[0]))
 
-    def test_grayscale_process_func(self):
-        # Note: Some, but not all, of the files are already grayscale
+    def test_greyscale_process_func(self):
+        self.check_skip()
+        # Note: Some, but not all, of the files are already greyscale
         # so in some cases this function does nothing.
-        def grayscale(image):
+        def greyscale(image):
             if image.ndim == 3:
                 image = image[:, :, 0]
                 assert image.ndim == 2
             return image
 
         v_raw = self.klass(self.filename, **self.kwargs)
-        v = self.klass(self.filename, grayscale, **self.kwargs)
-        assert_equal(v[0], grayscale(v_raw[0]))
+        v = self.klass(self.filename, greyscale, **self.kwargs)
+        assert_equal(v[0], greyscale(v_raw[0]))
 
+    def test_as_grey(self):
+        self.check_skip()
+        v = self.klass(self.filename, as_grey=True, **self.kwargs)
+        ndim = v[0].ndim
+        self.assertEqual(ndim, 2)
 
 class _frame_base_klass(_base_klass):
     def test_iterator(self):


### PR DESCRIPTION
This adopts `as_grey`, taking both the British-style naming and the smart calibration (assuming contemporary CRT phosphors) from similar functionality scikit-image.

This includes new tests and an overhaul of all the docstrings.

Closes #48 
