### PR TITLE
ENH: In notebook, default repr of Frame is PNG.

### DIFF
--- a/pims/frame.py
+++ b/pims/frame.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
+from io import BytesIO
 
 from numpy import ndarray, asarray
 
@@ -43,3 +44,12 @@ class Frame(ndarray):
 
         for attr, val in own_state.items():
             setattr(self, attr, val)
+
+    def _repr_png_(self):
+        from PIL import Image
+        x = asarray(Image.fromarray(self).resize((500, 500)))
+        x = (x - x.min()) / (x.max() - x.min())
+        img = Image.fromarray((x*256).astype('uint8'))
+        img_buffer = BytesIO()
+        img.save(img_buffer, format='png')
+        return img_buffer.getvalue()


### PR DESCRIPTION
I think the default display of a `Frame` in the notebook should be an image.

This does not change the output `print`, `repr`, `IPython.display_pretty`, and it does not affect any computations on a Frame. It only means that, in a notebook, the expression

```
frames[0]
```

displays a nicely sized image.
