### PR TITLE
TST/FIX: Implement metadata in Frame and test it on user-def class.

### DIFF
--- a/pims/frame.py
+++ b/pims/frame.py
@@ -14,11 +14,14 @@ class Frame(ndarray):
     def __new__(cls, input_array, frame_no=None, metadata=None):
         obj = asarray(input_array).view(cls)
         obj.frame_no = frame_no
-        obj.metadata = {}
+        if metadata is None:
+            metadata = {}
+        obj.metadata = metadata
         return obj
 
     def __array_finalize__(self, obj):
-        if obj is None: return
+        if obj is None:
+            return
         self.frame_no = getattr(obj, 'frame_no', None)
         self.metadata = getattr(obj, 'metadata', None)
 
@@ -48,7 +51,7 @@ class Frame(ndarray):
     def _repr_png_(self):
         from PIL import Image
         w = 500
-        h = self.shape[0] * w // self.shape[1] 
+        h = self.shape[0] * w // self.shape[1]
         x = asarray(Image.fromarray(self).resize((w, h)))
         x = (x - x.min()) / (x.max() - x.min())
         img = Image.fromarray((x*256).astype('uint8'))

--- a/pims/tests/test_frame.py
+++ b/pims/tests/test_frame.py
@@ -14,3 +14,11 @@ def test_scalar_casting():
     sum2 = tt.sum(keepdims=True)
     assert_equal(sum2.ndim, 2)
     assert_equal(sum2.frame_no, tt.frame_no)
+
+
+def test_creation_md():
+    md_dict = {'a': 1}
+    frame_no = 42
+    tt = Frame(np.ones((5, 3)), frame_no=frame_no, metadata=md_dict)
+    assert_equal(tt.metadata, md_dict)
+    assert_equal(tt.frame_no, frame_no)


### PR DESCRIPTION
Bugfix (pulled from #60) with associated test. Metadata was being ignored.
