### PR TITLE
Use libtiff reader on .lsm files.

### DIFF
--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -185,6 +185,11 @@ class TiffStack_libtiff(FramesSequence):
     --------
     TiffStack_pil, TiffStack_tiffile, ImageSequence
     """
+    @classmethod
+    def class_exts(cls):
+        # TODO extend this set to match reality
+        return {'lsm'} | super(TiffStack_libtiff, cls).class_exts()
+
     def __init__(self, filename, process_func=None, dtype=None,
                  as_grey=False):
         self._filename = filename


### PR DESCRIPTION
The libtiff-based flavor of `TiffStack_*` is the only one that opens Zeiss's '.lsm' files correctly.

Since there is not yet a mechanism for dealing with precedence, `TiffStack_tifffile` is the only reader registered to read tif/tiff files. This change does not interfere with that.
