### PR TITLE
ENH: Raise informatively if ImageSequence finds no files.

### DIFF
--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -90,6 +90,10 @@ class ImageSequence(FramesSequence):
         self._filepaths = filepaths
         self._count = len(self._filepaths)
 
+        # If there were no matches, this was probably a user typo.
+        if self._count == 0:
+            raise IOError("No files were found matching that path.")
+
         self._validate_process_func(process_func)
         self._as_grey(as_grey, process_func)
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -209,6 +209,10 @@ class TestImageSequenceWithPIL(_frame_base_klass):
     def test_count(self):
         assert_equal(len(self.v), 5)
 
+    def test_bad_path_raises(self):
+        raises = lambda: pims.ImageSequence('this/path/does/not/exist/*.jpg')
+        self.assertRaises(IOError, raises)
+
 
 class TestImageSequenceWithMPL(_frame_base_klass):
     def setUp(self):


### PR DESCRIPTION
Closes soft-matter/trackpy#156 as suggested by @mmdriscoll. Thanks!
