### PR TITLE
FIX: Handle more than 8-bit images in rich display.

### DIFF
--- a/pims/frame.py
+++ b/pims/frame.py
@@ -49,12 +49,17 @@ class Frame(ndarray):
             setattr(self, attr, val)
 
     def _repr_png_(self):
-        from PIL import Image
+        try:
+            from PIL import Image
+        except ImportError:
+            # IPython will show this exception as a warning unless
+            # _repr_png_() is explicitly called.
+            raise ImportError("Install PIL or Pillow to enable "
+                              "rich display of Frames.")
         w = 500
         h = self.shape[0] * w // self.shape[1]
-        x = asarray(Image.fromarray(self).resize((w, h)))
-        x = (x - x.min()) / (x.max() - x.min())
-        img = Image.fromarray((x*256).astype('uint8'))
+        x = (self - self.min()) / (self.max() - self.min())
+        img = Image.fromarray((x * 256).astype('uint8')).resize((w, h))
         img_buffer = BytesIO()
         img.save(img_buffer, format='png')
         return img_buffer.getvalue()

--- a/pims/tests/test_frame.py
+++ b/pims/tests/test_frame.py
@@ -22,3 +22,9 @@ def test_creation_md():
     tt = Frame(np.ones((5, 3)), frame_no=frame_no, metadata=md_dict)
     assert_equal(tt.metadata, md_dict)
     assert_equal(tt.frame_no, frame_no)
+
+
+def test_repr_png():
+    # This confims a bugfix, where 16-bit images would raise
+    # an error.
+    Frame(10000*np.ones((50, 50), dtype=np.uint16))._repr_png_()


### PR DESCRIPTION
A simple bugfix, extending the IPython rich display for Frames, `_repr_png_`, to images of any bit depth.
