### PR TITLE
FIX: Allow as_grey on RGBA images.

### DIFF
--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -101,7 +101,7 @@ class FramesStream(with_metaclass(ABCMeta, object)):
                     calibration = [0.2125, 0.7154, 0.0721]
                 else:
                     color_axis_size = 4
-                    calibration = [0.2125, 0.7154, 0.0721, 1]
+                    calibration = [0.2125, 0.7154, 0.0721, 0]
                 reduced_shape.remove(color_axis_size)
                 self._im_sz = tuple(reduced_shape)
                 def convert_to_grey(img):


### PR DESCRIPTION
Fix bug in PIMS that broke `as_grey` for images with an alpha channel.
