### PR TITLE
FIX: Handle alpha channel in grey conversion

### DIFF
--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -83,7 +83,7 @@ class FramesStream(with_metaclass(ABCMeta, object)):
         if as_grey:
             if process_func is not None:
                 raise ValueError("The as_grey option cannot be used when "
-                                 "process_func is specified. Incorpate "
+                                 "process_func is specified. Incorporate "
                                  "greyscale conversion in the function "
                                  "passed to process_func.")
             shape = self.frame_shape
@@ -108,6 +108,12 @@ class FramesStream(with_metaclass(ABCMeta, object)):
                     color_axis = img.shape.index(color_axis_size)
                     img = np.rollaxis(img, color_axis, 3)
                     grey = (img * calibration).sum(2)
+                    if rgba_like:
+                        alpha = img[:,:,3]
+                        BG_LUM = 1 # composite with white background
+                        # assume there is a pixel with no transparancy:
+                        max_alpha = np.max(alpha)
+                        grey = (alpha/max_alpha)*grey + (max_alpha-alpha)*BG_LUM
                     return grey.astype(img.dtype)  # coerce to original dtype
                 self.process_func = convert_to_grey
             else:


### PR DESCRIPTION
- Alpha channel is handled by compositing image on white background.
  Alpha is normalized to its max value in the image, to be able to handle
  different datatypes.
- Typo in ValueError

Follow-up on https://github.com/soft-matter/pims/pull/117
