### PR TITLE
FIX Change in way conda is installed

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ matrix:
       env: BUILD_MODE="pyav"
 
 install:
+  - conda install --yes -c conda conda-env
   - conda create -n testenv --yes numpy scipy nose pillow matplotlib scikit-image jinja2 pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff; fi


### PR DESCRIPTION
Travis started giving an error on `source activate testenv`. This should fix it.

quote from travis log:

    $ source activate testenv
    We're making conda environments even better!  Part of this process is
    changing the way environment activation works.  You need to install the
    new conda-env package before you can use these feature:
    conda install -c conda conda-env
    
    For more information, please visit: https://github.com/conda/conda-env