### PR TITLE
FIX Display function interprets `colors` metadata

### DIFF
--- a/pims/display.py
+++ b/pims/display.py
@@ -311,7 +311,7 @@ def to_rgb(image, colors=None, normalize=True):
         datatype is np.uint8, else it is float.
     """
     # identify whether the image has a (leading) channel axis
-    if colors == None:
+    if colors is None:
         has_channel_axis = image.ndim > 2 and image.shape[0] < 5
     else:
         has_channel_axis = len(colors) == image.shape[0]

--- a/pims/display.py
+++ b/pims/display.py
@@ -310,9 +310,13 @@ def to_rgb(image, colors=None, normalize=True):
         so that values lay between 0 and 255. When normalize = True (default),
         datatype is np.uint8, else it is float.
     """
+    # identify whether the image has a (leading) channel axis
+    if colors == None:
+        has_channel_axis = image.ndim > 2 and image.shape[0] < 5
+    else:
+        has_channel_axis = len(colors) == image.shape[0]
     # identify number of channels and resulting shape
-    is_multichannel = image.ndim > 2 and image.shape[0] < 5
-    if is_multichannel:
+    if has_channel_axis:
         channels = image.shape[0]
         shape_rgb = image.shape[1:] + (3,)
     else:
@@ -339,7 +343,7 @@ def to_rgb(image, colors=None, normalize=True):
         rgbs = (ColorConverter().to_rgba_array(colors)*255).astype('uint8')
         rgbs = rgbs[:channels, :3]
 
-    if is_multichannel:
+    if has_channel_axis:
         result = np.zeros(shape_rgb)
         for i in range(channels):
             result += _monochannel_to_rgb(image[i], rgbs[i])

--- a/pims/frame.py
+++ b/pims/frame.py
@@ -75,16 +75,20 @@ class Frame(ndarray):
     def _repr_html_(self):
         from jinja2 import Template
         # Identify whether image is multichannel, convert to rgb if necessary
-        if self.ndim > 2 and self.shape[0] < 5:
-            try:
-                colors = self.metadata['colors']
-            except KeyError or AttributeError:
-                colors = None
+        try:
+            # if colors field exists, check if size agrees with image shape
+            colors = self.metadata['colors']
+            is_multichannel = len(colors) == 1 or len(colors) == self.shape[0]         
+        except KeyError or AttributeError:
+            # if colors field does not exist, guess from image shape
+            colors = None
+            is_multichannel = self.ndim > 2 and self.shape[0] < 5
+        if is_multichannel:
             image = to_rgb(self, colors, False)
             has_color_channels = True
         else:
             image = self
-            has_color_channels = (3 in image.shape) or (4 in image.shape)
+            has_color_channels = image.shape[-1] == 3 or image.shape[-1] == 4
         # If Frame is 2D, display as a plain image.
         # We have to build the image tag ourselves; _repr_html_ expects HTML.
         if image.ndim == 2 or (image.ndim == 3 and has_color_channels):


### PR DESCRIPTION
It was already implented but still buggy. The rich display function now correctly interpret `colors` field in metadata dictionary.

Additional fix: PIL doesn't take RGB images with RGB axis at a position other than the inner position (tested with (3, 256, 512) shaped array). So I changed the definition of `has_color_channels`. This has the advantage that depth-3 and depth-4 z-stacks get viewed correctly.