### PR TITLE
ENH: Bioformats crop + minor fix

### DIFF
--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -70,6 +70,13 @@ class MetadataRetrieve(object):
                 return None
             # convert value to int, float, or string
             jw = str(jw)
+            try:  # deal with values hidden inside 'value[number]'
+                temp = jw[jw.index('value[') + 6:]
+                temp = temp[:temp.index(']')]
+            except ValueError:
+                pass  # do nothing when 'value[' or ']' were not found
+            else:
+                jw = temp
             try:
                 return int(jw)
             except ValueError:

--- a/pims/tests/test_bioformats.py
+++ b/pims/tests/test_bioformats.py
@@ -190,6 +190,14 @@ class TestBioformatsTiff(_image_series):
         assert_image_equal(self.v[0], self.frame0)
         assert_image_equal(self.v[1], self.frame1)
 
+    def test_cropping(self):
+        self.v.crop = (0, 60, 10, 20)  # YXHW
+        assert_image_equal(self.v[0], self.frame0[:10, 60:80])
+        assert_image_equal(self.v[1], self.frame1[:10, 60:80])
+        self.v.crop = None
+        assert_image_equal(self.v[0], self.frame0)
+        assert_image_equal(self.v[1], self.frame1)
+
     def tearDown(self):
         self.v.close()
 


### PR DESCRIPTION
This enhancement makes use of the built-in cropping methods of bioformats. Useful for very big images. It works like this:

    frames = pims.frames(filename)
    frames.crop = (20, 20, 100, 100)  # get a 100x100 frame with origin 20, 20
    assert frames[0].shape == (100, 100)

Additionally, there is a minor fix for metadata reading with bioformats 5.1.x.