### PR TITLE
ENH: Image sequence in zipfiles

### DIFF
--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -5,8 +5,11 @@ import six
 from six.moves import map
 import os
 import glob
+import fnmatch
 from warnings import warn
 import re
+import zipfile
+from StringIO import StringIO
 
 import numpy as np
 
@@ -16,6 +19,7 @@ from pims.utils.sort import natural_keys
 
 # skimage.io.plugin_order() gives a nice hierarchy of implementations of imread.
 # If skimage is not available, go down our own hard-coded hierarchy.
+from PIL import Image
 try:
     from skimage.io import imread
 except ImportError:
@@ -32,9 +36,10 @@ class ImageSequence(FramesSequence):
     Parameters
     ----------
     path_spec : string or iterable of strings
-       a directory or, safer, a pattern like path/to/images/*.png
-       which will ignore extraneous files or a list of files to open
-       in the order they should be loaded.
+        a directory or, safer, a pattern like path/to/images/*.png
+        which will ignore extraneous files or a list of files to open
+        in the order they should be loaded. When a path to a zipfile is
+        specified, all files in the zipfile will be loaded.
     process_func : function, optional
         callable with signalture `proc_img = process_func(img)`,
         which will be applied to the data from each frame
@@ -46,7 +51,7 @@ class ImageSequence(FramesSequence):
     plugin : string
         Passed on to skimage.io.imread if scikit-image is available.
         If scikit-image is not available, this will be ignored and a warning
-        will be issued.
+        will be issued. Not available in combination with zipfiles.
 
     Examples
     --------
@@ -94,6 +99,20 @@ class ImageSequence(FramesSequence):
         else:
             self._dtype = dtype
 
+    def close(self):
+        if self.is_zipfile:
+            self.zipfile.close()
+
+    def __del__(self):
+        self.close()
+
+    def imread(self, filename, **kwargs):
+        if self.is_zipfile:
+            img = StringIO(self.zipfile.read(filename))
+            return Image.open(img, **kwargs)
+        else:
+            return imread(filename)
+
     def _get_files(self, path_spec):
         # deal with if input is _not_ a string
         if not isinstance(path_spec, six.string_types):
@@ -102,6 +121,17 @@ class ImageSequence(FramesSequence):
             self._count = len(path_spec)
             return
 
+        if zipfile.is_zipfile(path_spec):
+            self.is_zipfile = True
+            self.pathname = os.path.abspath(path_spec)
+            self.zipfile = zipfile.ZipFile(path_spec, 'r')
+            filepaths = [fn for fn in self.zipfile.namelist()
+                         if fnmatch.fnmatch(fn, '*.*')]
+            self._filepaths = sorted(filepaths, key=natural_keys)
+            self._count = len(self._filepaths)
+            return
+
+        self.is_zipfile = False
         self.pathname = os.path.abspath(path_spec)  # used by __repr__
         if os.path.isdir(path_spec):
             warn("Loading ALL files in this directory. To ignore extraneous "
@@ -114,8 +144,7 @@ class ImageSequence(FramesSequence):
             filepaths = list(map(make_full_path, filenames))
         else:
             filepaths = glob.glob(path_spec)
-        filepaths = sorted(filepaths, key=natural_keys)  # listdir returns arbitrary order
-        self._filepaths = filepaths
+        self._filepaths = sorted(filepaths, key=natural_keys)
         self._count = len(self._filepaths)
 
         # If there were no matches, this was probably a user typo.
@@ -125,7 +154,7 @@ class ImageSequence(FramesSequence):
     def get_frame(self, j):
         if j > self._count:
             raise ValueError("File does not contain this many frames")
-        res = imread(self._filepaths[j], **self.kwargs)
+        res = self.imread(self._filepaths[j], **self.kwargs)
         if res.dtype != self._dtype:
             res = res.astype(self._dtype)
         res = Frame(self.process_func(res), frame_no=j)
@@ -201,11 +230,12 @@ class ImageSequence3D(ImageSequence):
     Parameters
     ----------
     path_spec : string or iterable of strings
-       a directory or, safer, a pattern like path/to/images/*.png
-       which will ignore extraneous files or a list of files to open
-       in the order they should be loaded. The filenames should contain the
-       indices of T, Z and C, preceded by a dimension identifier such as:
-       'file_t001c05z32'.
+        a directory or, safer, a pattern like path/to/images/*.png
+        which will ignore extraneous files or a list of files to open
+        in the order they should be loaded. When a path to a zipfile is
+        specified, all files in the zipfile will be loaded. The filenames
+        should contain the indices of T, Z and C, preceded by a dimension
+        identifier such as: 'file_t001c05z32'.
     process_func : function, optional
         callable with signalture `proc_img = process_func(img)`,
         which will be applied to the data from each frame
@@ -216,7 +246,7 @@ class ImageSequence3D(ImageSequence):
     plugin : string
         Passed on to skimage.io.imread if scikit-image is available.
         If scikit-image is not available, this will be ignored and a warning
-        will be issued.
+        will be issued. Not available in combination with zipfiles.
     tzc_identifiers : list of string, optional
         3 strings preceding t, z, c indices. Default ['t', 'z', 'c'].
 
@@ -251,7 +281,7 @@ class ImageSequence3D(ImageSequence):
                                       self._toc[:, 2] == c)
             filelist = self._filepaths[selector]
             for (z, loc) in enumerate(filelist):
-                res[Nc, z] = imread(loc, **self.kwargs)
+                res[Nc, z] = self.imread(loc, **self.kwargs)
 
         return Frame(self.process_func(res.squeeze()), frame_no=j)
 

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -9,7 +9,7 @@ import fnmatch
 from warnings import warn
 import re
 import zipfile
-from StringIO import StringIO
+from six.moves import StringIO
 
 import numpy as np
 

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -90,7 +90,7 @@ class ImageSequence(FramesSequence):
         self._zipfile = None
         self._get_files(path_spec)
 
-        tmp = imread(self._filepaths[0], **self.kwargs)
+        tmp = self.imread(self._filepaths[0], **self.kwargs)
         self._first_frame_shape = tmp.shape
 
         self._validate_process_func(process_func)
@@ -104,6 +104,7 @@ class ImageSequence(FramesSequence):
     def close(self):
         if self._is_zipfile:
             self._zipfile.close()
+        super(ImageSequence, self).close()
 
     def __del__(self):
         self.close()
@@ -111,7 +112,7 @@ class ImageSequence(FramesSequence):
     def imread(self, filename, **kwargs):
         if self._is_zipfile:
             img = StringIO(self._zipfile.read(filename))
-            return Image.open(img)
+            return np.array(Image.open(img))
         else:
             return imread(filename, **kwargs)
 


### PR DESCRIPTION
When a path to a zipfile is specified, all files inside the zipfile will be loaded as an imagesequence using `PIL.Image.open`. For large collections of images, it may be preferred to work from zipfiles.