### PR TITLE
FIX: Double byteswap in libtiff

### DIFF
--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -210,8 +210,6 @@ class TiffStack_libtiff(FramesSequence):
 
         self._im_sz = tmp.shape
 
-        self._byte_swap = bool(self._tiff.IsByteSwapped())
-
         self._validate_process_func(process_func)
         self._as_grey(as_grey, process_func)
 
@@ -219,7 +217,7 @@ class TiffStack_libtiff(FramesSequence):
         if j > self._count:
             raise ValueError("File does not contain this many frames")
         self._tiff.SetDirectory(j)
-        res = self._tiff.read_image().byteswap(self._byte_swap)
+        res = self._tiff.read_image()
         if res.dtype != self._dtype:
             res = res.astype(self._dtype)
 


### PR DESCRIPTION
Follow-up on https://github.com/soft-matter/pims/issues/141.

Probably there is a superfluous byteswap done in pims `TiffStack_libtiff`.

After inspecting the source of Tiff.read_image it appears that ReadEncodedStrip underlies this function. According to https://bitmiracle.github.io/libtiff.net/html/2ee23e7c-3bdf-3dcf-c22e-909bf9a5cd01.htm this does the byteswapping for you. So probably it is swapped one time to much right now.

I tried to install libtiff on my Win64 computer, but I encountered some problems having to do with 32/64 bits. So I cannot test it right now. It should solve https://github.com/soft-matter/pims/issues/141. @tacaswell, could you test if this issue is solved?

**edit: apparently it breaks the test on stuck.tif. But I am still curious if it fixes #141 ... **