### PR TITLE
Bioformats jpype

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,9 +8,26 @@ build/*
 dist/*
 pims.egg-info/*
 pims/version.py
+pims/loci_tools.jar
 examples/.ipynb_checkpoints
 pims/tests/data/bulk-water.mov.pims_buffer
 pims/tests/data/bulk-water.mov.pims_meta
+pims/tests/data/bioformats/2chZT.lsm
+pims/tests/data/bioformats/Blend_Final.IPL
+pims/tests/data/bioformats/dnasample1.dm3
+pims/tests/data/bioformats/HEART.SEQ
+pims/tests/data/bioformats/leica_stack.lei
+pims/tests/data/bioformats/leica_stack.txt
+pims/tests/data/bioformats/leica_stack_Series014_z000_ch00.tif
+pims/tests/data/bioformats/leica_stack_Series014_z001_ch00.tif
+pims/tests/data/bioformats/leica_stack_Series014_z002_ch00.tif
+pims/tests/data/bioformats/mitosis-test.ipw
+pims/tests/data/bioformats/mouse-kidney.lif
+pims/tests/data/bioformats/qdna1.ics
+pims/tests/data/bioformats/qdna1.ids
+pims/tests/data/bioformats/readme.txt
+pims/tests/data/bioformats/wtembryo.mov
+
 
 # pycharm IDE
 .idea/

--- a/.gitignore
+++ b/.gitignore
@@ -12,15 +12,14 @@ pims/loci_tools.jar
 examples/.ipynb_checkpoints
 pims/tests/data/bulk-water.mov.pims_buffer
 pims/tests/data/bulk-water.mov.pims_meta
+pims/tests/data/bioformats/10-31 E1.tif
 pims/tests/data/bioformats/2chZT.lsm
 pims/tests/data/bioformats/Blend_Final.IPL
 pims/tests/data/bioformats/dnasample1.dm3
 pims/tests/data/bioformats/HEART.SEQ
-pims/tests/data/bioformats/leica_stack.lei
-pims/tests/data/bioformats/leica_stack.txt
-pims/tests/data/bioformats/leica_stack_Series014_z000_ch00.tif
-pims/tests/data/bioformats/leica_stack_Series014_z001_ch00.tif
-pims/tests/data/bioformats/leica_stack_Series014_z002_ch00.tif
+pims/tests/data/bioformats/KEVIN2-3*
+pims/tests/data/bioformats/leica_stack*
+pims/tests/data/bioformats/MF-2CH-Z-T.tif
 pims/tests/data/bioformats/mitosis-test.ipw
 pims/tests/data/bioformats/mouse-kidney.lif
 pims/tests/data/bioformats/qdna1.ics

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,8 @@ install:
   - conda update --yes conda
   - conda create -n testenv --yes numpy scipy nose pillow matplotlib scikit-image jinja2 pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff jpype1; fi
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff; fi
+  - pip install jpype1;
   - export LD_LIBRARY_PATH=/usr/local/lib LIBRARY=ffmpeg;
   - wget https://raw.githubusercontent.com/mikeboers/PyAV/master/scripts/test-setup;
   - bash ./test-setup;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,33 +1,18 @@
 language: python
 
-matrix:
-  include: 
-    - python: "2.7"
-      env: BUILD_MODE="pyav"
-    - python: "2.7"
-      env: BUILD_MODE="bioformats"
-    - python: "3.4"
-      env: BUILD_MODE="pyav"
+python:
+  - 2.7
+  - 3.4
 
 install:
   - conda update --yes conda
   - conda create -n testenv --yes numpy scipy nose pillow matplotlib scikit-image jinja2 pip python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff; fi
-  - if [ $BUILD_MODE == "bioformats" ]; 
-    then 
-        sudo apt-get install default-jdk;
-        pip install https://github.com/originell/jpype/archive/master.zip;
-    fi
-  - if [ $BUILD_MODE == "pyav" ]; 
-    then 
-        export LD_LIBRARY_PATH=/usr/local/lib LIBRARY=ffmpeg;
-        wget https://raw.githubusercontent.com/mikeboers/PyAV/master/scripts/test-setup;
-        bash ./test-setup;
-        rm ~/miniconda/envs/testenv/lib/libm.so.6;
-        rm ~/miniconda3/envs/testenv/lib/libm.so.6;
-        pip install av;
-    fi
+  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff jpype1; fi
+  - export LD_LIBRARY_PATH=/usr/local/lib LIBRARY=ffmpeg;
+  - wget https://raw.githubusercontent.com/mikeboers/PyAV/master/scripts/test-setup;
+  - bash ./test-setup;
+  - pip install av;
   - python setup.py build_ext install
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,7 @@ install:
   - if [ $BUILD_MODE == "bioformats" ]; 
     then 
         sudo apt-get install default-jdk;
-        pip install javabridge;
-        pip install https://github.com/CellProfiler/python-bioformats/archive/master.zip;
+        pip install https://github.com/originell/jpype/archive/master.zip;
     fi
   - if [ $BUILD_MODE == "pyav" ]; 
     then 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ One of the following is required:
 Depending on what file formats you want to read, you will also need:
 
 * [ffmpeg](https://www.ffmpeg.org/) and [PyAV](http://mikeboers.github.io/PyAV/) (video formats such as AVI, MOV)
+* [jpype](http://jpype.readthedocs.org/en/latest/) (interface with bioformats to support [many](https://www.openmicroscopy.org/site/support/bio-formats5.1/supported-formats.html) microscopy formats)
 * [Pillow](http://pillow.readthedocs.org/en/latest/) (improved TIFF support)
 * [libtiff](https://code.google.com/p/pylibtiff/) (alternative TIFF support)
 * [tifffile](http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html) (alterative TIFF support)
@@ -83,6 +84,22 @@ But if either FFmpeg or libav is available, PIMS enables fast random access to
 video files. It relies on PyAV, which can be installed like so:
 
     pip install av
+
+### Reading microscopy files via Bio-Formats
+
+([List of supported formats](https://www.openmicroscopy.org/site/support/bio-formats5.1/supported-formats.html))
+
+Bio-Formats is an open-source java library for reading and writing
+multidimensional image data, especially from microscopy files. To interface
+with the java library, we use [JPype](https://github.com/originell/jpype) which
+allows fast and easy access to all java functions. JRE or JDK are not required.
+Install JPype as follows:
+
+    pip install jpype1
+
+On first use of `pims.Bioformats(filename)`, the required java library
+`loci_tools.jar` will be automatically downloaded from
+[openmicroscopy.org](http://downloads.openmicroscopy.org/bio-formats/).
 
 #### Troubleshooting
 

--- a/download_bioformats_test.py
+++ b/download_bioformats_test.py
@@ -3,15 +3,12 @@ source: http://loci.wisc.edu/software/sample-data
 
 Approx. download size: 311 MB"""
 
-
 def download_bioformats_tstfiles():
-    try:
-        import bioformats
-        import javabridge
-    except ImportError:
-        raise ImportError("Bioformats and/or javabridge were not found, these "
-                          "are required for running tests on these files.")
     import os
+    try:
+        import jpype
+    except ImportError:
+        raise ImportError("JPype is required for running tests on these files.")
     from six.moves.urllib.request import urlretrieve
     from zipfile import ZipFile
 

--- a/download_bioformats_test.py
+++ b/download_bioformats_test.py
@@ -1,7 +1,5 @@
 """This script downloads the necessary files for bioformats unittests
-source: http://loci.wisc.edu/software/sample-data
-
-Approx. download size: 311 MB"""
+source: http://loci.wisc.edu/software/sample-data"""
 
 def download_bioformats_tstfiles():
     import os
@@ -23,16 +21,19 @@ def download_bioformats_tstfiles():
         with ZipFile(fn) as zf:
             zf.extractall(filepath)
         os.remove(fn)
+        if os.path.isfile('readme.txt'):
+            os.remove('readme.txt')
 
     passing = ['qdna1.zip', 'leica_stack.zip', 'Blend_Final.zip', 'HEART.zip',
                'wtembryo.zip', 'mitosis-test.zip', 'dnasample1.zip',
-               '2chZT.zip', 'mouse-kidney.zip']
+               '2chZT.zip', 'mouse-kidney.zip', 'MF-2CH-Z-T.zip',
+               '10-31%20E1.zip', 'KEVIN2-3.zip']
 
-    # failing = ['MF-2CH-Z-T.zip', 'sdub.zip', 'NESb.zip', 'TAABA.zip',
-    #            '10-31%20E1.zip', 'KEVIN2-3.zip', 'embryo2.zip', 'dub.zip']
+    #failing = ['sdub.zip', 'NESb.zip', 'TAABA.zip', 'embryo2.zip', 'dub.zip']
 
     for fn in passing:
         get_bioformats_file(fn, path)
+        print('Downloaded {}'.format(fn))
 
 if __name__ == '__main__':
     download_bioformats_tstfiles()

--- a/pims/api.py
+++ b/pims/api.py
@@ -48,12 +48,11 @@ try:
     if pims.bioformats.available():
         BioformatsRaw = pims.bioformats.BioformatsReaderRaw
         Bioformats = pims.bioformats.BioformatsReader
-        from javabridge import kill_vm
     else:
         raise ImportError()
 except (ImportError, IOError):
-    BioformatsRaw = not_available("javabridge and bioformats")
-    Bioformats = not_available("javabridge and bioformats")
+    BioformatsRaw = not_available("JPype")
+    Bioformats = not_available("JPype")
 
 
 def open(sequence, process_func=None, dtype=None, as_grey=False, plugin=None):

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -205,16 +205,16 @@ class BioformatsReaderRaw(FramesSequence):
     done when JPype is unloaded at python exit.
 
     Dependencies:
-    http://sourceforge.net/projects/jpype/files/JPype/
+    https://pypi.python.org/pypi/JPype1
 
     Tested with files from http://loci.wisc.edu/software/sample-data
     Working for:
         Zeiss Laser Scanning Microscopy, IPLab, Gatan Digital Micrograph,
         Image-Pro sequence, Leica, Image-Pro workspace, Nikon NIS-Elements ND2,
-        Image Cytometry Standard, QuickTime movie
-    Not (fully) working for:
-        Olympus Fluoview TIFF, Bio-Rad PIC, Openlab LIFF, PerkinElmer,
-        Andor Bio-imaging Division TIFF, Leica LIF, BIo-Rad PIC
+        Image Cytometry Standard, QuickTime movie, Olympus Fluoview TIFF,
+        Andor Bio-imaging Division TIFF, PerkinElmer, Leica LIF
+
+    Bio-Rad PIC and Openlab LIFF can only be loaded as single frames
 
     For files larger than 4GB, 64 bits Python is required
 
@@ -576,16 +576,16 @@ class BioformatsReader(BioformatsReaderRaw):
     done when JPype is unloaded at python exit.
 
     Dependencies:
-    http://sourceforge.net/projects/jpype/files/JPype/
+    https://pypi.python.org/pypi/JPype1
 
     Tested with files from http://loci.wisc.edu/software/sample-data
     Working for:
         Zeiss Laser Scanning Microscopy, IPLab, Gatan Digital Micrograph,
         Image-Pro sequence, Leica, Image-Pro workspace, Nikon NIS-Elements ND2,
-        Image Cytometry Standard, QuickTime movie
-    Not (fully) working for:
-        Olympus Fluoview TIFF, Bio-Rad PIC, Openlab LIFF, PerkinElmer,
-        Andor Bio-imaging Division TIFF, Leica LIF, BIo-Rad PIC
+        Image Cytometry Standard, QuickTime movie, Olympus Fluoview TIFF,
+        Andor Bio-imaging Division TIFF, PerkinElmer, Leica LIF
+
+    Bio-Rad PIC and Openlab LIFF can only be loaded as single frames
 
     For files larger than 4GB, 64 bits Python is required
 

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -20,6 +20,15 @@ def available():
 
 
 def download_jar(url=None, overwrite=False):
+    """Downloads loci_tools.jar from openmicroscopy into the pims root folder.
+
+    Parameters
+    ----------
+    url: string
+        specifies a custom loci_tools.jar url, for instance to change version
+    overwrite: boolean
+        set overwrite=True to overwrite the existing loci_tools without notice
+    """
     from six.moves.urllib.request import urlretrieve
     if not overwrite and os.path.isfile(LOCI_TOOLS_PATH):
         raise IOError('File {} already exists, please backup the file or set '
@@ -32,12 +41,15 @@ def download_jar(url=None, overwrite=False):
 
 
 def _jbytearr_fast(arr, dtype):
+    # see https://github.com/originell/jpype/issues/71 and
+    # https://github.com/originell/jpype/pull/73
     Jstr = jpype.java.lang.String(arr, 'ISO-8859-1').toString()
     bytearr = np.array(np.frombuffer(Jstr, dtype=np.uint16), dtype=np.byte)
     return np.frombuffer(buffer(bytearr), dtype=dtype)
 
 
 def _jbytearr_slow(arr, dtype, bpp, fp, little_endian):
+    # let java do the type conversion
     Jconv = loci.common.DataTools.makeDataArray(arr, bpp, fp, little_endian)
     return np.array(Jconv, dtype=dtype)
 

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -24,23 +24,20 @@ def _gen_jar_locations():
     The precedence order is (highest priority first):
 
     1. pims package location
-    2. /etc/loci_tools.jar
-    3. CONDA_ENV/etc/loci_tools.jar
-    4. PROGRAMDATA/pims/loci_tools.jar
-    5. LOCALAPPDATA/pims/loci_tools.jar
-    6. APPDATA/pims/loci_tools.jar
-    7. ~/.config/pims/loci_tools.jar
+    2. PROGRAMDATA/pims/loci_tools.jar
+    3. LOCALAPPDATA/pims/loci_tools.jar
+    4. APPDATA/pims/loci_tools.jar
+    5. /etc/loci_tools.jar
+    6. ~/.config/pims/loci_tools.jar
     """
     yield os.path.dirname(__file__)
-    yield '/etc'
-    if 'CONDA_ETC_' in os.environ:
-        yield os.environ['CONDA_ETC_']
     if 'PROGRAMDATA' in os.environ:
         yield os.path.join(os.environ['PROGRAMDATA'], 'pims')
     if 'LOCALAPPDATA' in os.environ:
         yield os.path.join(os.environ['LOCALAPPDATA'], 'pims')
     if 'APPDATA' in os.environ:
         yield os.path.join(os.environ['APPDATA'], 'pims')
+    yield '/etc'
     yield os.path.join(os.path.expanduser('~'), '.config', 'pims')
 
 

--- a/pims/tests/test_bioformats.py
+++ b/pims/tests/test_bioformats.py
@@ -301,6 +301,54 @@ class TestBioformatsLSM(_image_series, _image_stack, _image_multichannel):
     def tearDown(self):
         self.v.close()
 
+class TestBioformatsAndorTiff(_image_series, _image_stack, _image_multichannel):
+    # Andor Bio-imaging Division TIFF format, 256 x 256 pixels, 16 bits per sample
+    # 5 time points, 4 focal planes, 2 channels
+    # Mark Browne of Andor Technology's Bio-imaging Division has provided a
+    # multifield, 2-channel Z-T series in ABD TIFF format.
+    def check_skip(self):
+        _skip_if_no_bioformats()
+        if not os.path.isfile(self.filename):
+            raise nose.SkipTest('File missing. Skipping.')
+
+    def setUp(self):
+        self.filename = os.path.join(path, 'bioformats', 'MF-2CH-Z-T.tif')
+        self.check_skip()
+        self.klass = pims.Bioformats
+        self.kwargs = {'meta': False}
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = (256, 256)
+        self.expected_len = 5
+        self.expected_C = 2
+        self.expected_Z = 4
+
+    def tearDown(self):
+        self.v.close()
+
+
+class TestBioformatsOlympusTiff(_image_series, _image_stack):
+    # Olympus Fluoview TIFF format, 512 x 512 pixels, 16 bits per sample
+    # 16 time points, 21 focal planes
+    # Timothy Gomez of the Department of Anatomy at the UW-Madison has provided
+    # a 4D series in Fluoview TIFF format.
+    def check_skip(self):
+        _skip_if_no_bioformats()
+        if not os.path.isfile(self.filename):
+            raise nose.SkipTest('File missing. Skipping.')
+
+    def setUp(self):
+        self.filename = os.path.join(path, 'bioformats', '10-31 E1.tif')
+        self.check_skip()
+        self.klass = pims.Bioformats
+        self.kwargs = {'meta': False}
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = (512, 512)
+        self.expected_len = 16
+        self.expected_Z = 21
+
+    def tearDown(self):
+        self.v.close()
+
 
 class TestBioformatsLIFseries1(_image_single, _image_stack, _image_multichannel):
     # Leica LIF format, 512 x 512 pixels, 16 bits per sample
@@ -445,6 +493,30 @@ class TestBioformatsICS(_image_single):
         self.v = self.klass(self.filename, **self.kwargs)
         self.expected_shape = (256, 256)
         self.expected_len = 1
+
+    def tearDown(self):
+        self.v.close()
+
+
+class TestBioformatsZPO(_image_stack, _image_multichannel):
+    # PerkinElmer format, 672 x 512 pixels
+    # 1 time point, 29 focal planes, 3 channels
+    # Kevin O'Connell of NIH/NIDDK's Laboratory of Biochemistry and Genetics
+    # has provided a multichannel 4D series in PerkinElmer format.
+    def check_skip(self):
+        _skip_if_no_bioformats()
+        if not os.path.isfile(self.filename):
+            raise nose.SkipTest('File missing. Skipping.')
+
+    def setUp(self):
+        self.filename = os.path.join(path, 'bioformats', 'KEVIN2-3.zpo')
+        self.check_skip()
+        self.klass = pims.Bioformats
+        self.kwargs = {'meta': False}
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = (672, 512)
+        self.expected_C = 3
+        self.expected_Z = 29
 
     def tearDown(self):
         self.v.close()


### PR DESCRIPTION
I had some persistent issues with the Bioformats reader having to do with very slow reading times and crashes on large files. So I tried out another java interface `jpype` and it appears to be approx 20x faster and easier to use. Additionally, it will probably be going to support Py3 soon. And it doesn't conflict with PyAv.

Some minor changes:
- MetadataRetrieve are now called without `get`, i.e. `frames.metadata.PlaneTheC(0,0)` instead of
`frames.metadata.getPlaneTheC(0,0)`
- For some reason, pictures do not get recognized as RGB but (for all my tests) as 3-channel picture. I think this is an improvement.
- kill_vm or, with JPype, ShutdownJVM is not necessary as this is called automatically on python exit
- loci_tools.jar is automatically downloaded when reader is called and loci_tools.jar is not found in pims root folder