### PR TITLE
FIX Fixes wrong use of ndarray.byteswap in TiffStack_libtiff

### DIFF
--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -219,7 +219,9 @@ class TiffStack_libtiff(FramesSequence):
         if j > self._count:
             raise ValueError("File does not contain this many frames")
         self._tiff.SetDirectory(j)
-        res = self._tiff.read_image().byteswap(self._byte_swap)
+        res = self._tiff.read_image()
+        if self._byte_swap:
+            res = res.newbyteorder()
         if res.dtype != self._dtype:
             res = res.astype(self._dtype)
 


### PR DESCRIPTION
This fixes https://github.com/soft-matter/pims/issues/141. The parameter in `ndarray.byteswap()` determines whether the byteswap is inplace. So the use was wrong.

Also, `ndarray.newbyteorder()` changes the dtype byteorder instead of physically swapping the data.