### PR TITLE
ENH: Slicing on a pims reader returns reusable, sliceable, sized objects.

### DIFF
--- a/pims/api.py
+++ b/pims/api.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from pims.base_frames import FramesSequence
+from pims.base_frames import FramesSequence, SliceableIterable
 from pims.frame import Frame
 from pims.display import (export, play, scrollable_stack, to_rgb, normalize,
                           plot_to_frame, plots_to_frame)

--- a/pims/api.py
+++ b/pims/api.py
@@ -1,7 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from pims.base_frames import FramesSequence, SliceableIterable
+from pims.base_frames import FramesSequence, SliceableIterable, pipeline
 from pims.frame import Frame
 from pims.display import (export, play, scrollable_stack, to_rgb, normalize,
                           plot_to_frame, plots_to_frame)

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -225,7 +225,7 @@ class SliceableIterable(object):
                 # if we have a bool array, set up masking but defer
                 # the actual computation, returning another SliceableIterable
                 rel_indices = np.arange(len(self))[key]
-                indices = index_generator(rel_indices, abs_indices)
+                indices = _index_generator(rel_indices, abs_indices)
                 new_length = key.sum()
                 return SliceableIterable(self._ancestor, indices, new_length)
             if any(_k < -_len or _k >= _len for _k in key):

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -215,7 +215,8 @@ class SliceableIterable(object):
             rel_indices = range(*key.indices(_len))
             indices = _index_generator(rel_indices, abs_indices)
             start, stop, step = key.indices(_len)
-            new_length = (stop - start) // step
+            # There is fenceposting subtlety in knowing the length of a slice.
+            new_length = 1 + (stop - start - 1) // step
             return SliceableIterable(self._ancestor, indices, new_length)
         elif isinstance(key, collections.Iterable):
             # if the input is an iterable, doing 'fancy' indexing

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -143,8 +143,8 @@ class SliceableIterable(object):
         object like itself, a SliceableIterable. When sliced with an integer,
         it returns the data payload.
 
-        Also, this retains the attributes of the "ancestor" object that
-        created it.
+        Also, this retains the attributes of the ultimate ancestor that
+        created it (or its parent, or its parent's parent, ...).
 
         Parameters
         ----------

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -3,7 +3,7 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 from six import with_metaclass
-from six.moves import xrange
+from six.moves import range
 import os
 import numpy as np
 import collections
@@ -151,7 +151,7 @@ class FramesSequence(FramesStream):
         if isinstance(key, slice):
             # if input is a slice, return a generator
             return (self.get_frame(_k) for _k
-                    in xrange(*key.indices(_len)))
+                    in range(*key.indices(_len)))
         elif isinstance(key, collections.Iterable):
             # if the input is an iterable, doing 'fancy' indexing
 

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -250,6 +250,10 @@ class SliceableIterable(object):
 
             return self._ancestor[key if key >= 0 else _len + key]
 
+    def close(self):
+        "Closing this child slice of the original reader does nothing."
+        pass
+
 
 class FramesSequence(FramesStream):
     """Baseclass for wrapping data buckets that have random access.

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -270,7 +270,7 @@ class FramesSequence(FramesStream):
         """If getting a scalar, a specific frame, call get_frame. Otherwise,
         be 'lazy' and defer to the slicing logic of SliceableIterable."""
         if isinstance(key, int):
-            return self.get_frame(key)
+            return self.get_frame(key if key >= 0 else len(self) + key)
         else:
             return SliceableIterable(self, range(len(self)), len(self))[key]
 

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -135,7 +135,7 @@ Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
 
 class SliceableIterable(object):
 
-    def __init__(self, ancestor, indices, length):
+    def __init__(self, ancestor, indices, length=None):
         """A generator that support fancy indexing, returning another generator
 
         Also, this retains the attributes of the "ancestor" object that
@@ -149,7 +149,8 @@ class SliceableIterable(object):
             giving indices into `ancestor`
         length: integer
             length of indicies
-            (must be given explicitly because indices may be a generator)
+            This must be given explicitly if indices is a generator,
+            that is, if `len(indices)` is invalid
 
         Examples
         --------
@@ -169,6 +170,12 @@ class SliceableIterable(object):
         >>> type(v3)
         generator
         """
+        if length is None:
+            try:
+                length = len(indices)
+            except TypeError:
+                raise ValueError("The length parameter is required in this "
+                                 "case because len(indices) is not valid.")
         self._len = length
         self._ancestor = ancestor
         self._indices = indices
@@ -227,7 +234,8 @@ class SliceableIterable(object):
                 new_length = len(self._indices)
             except TypeError:
                 # The key is a generator; return a plain old generator.
-                # Without knowing the length, we can't give a SliceableIterable
+                # Without knowing the length of the *key*,
+                # we can't give a SliceableIterable
                 gen = (self[_k if _k >= 0 else _len + _k] for _k in key)
                 return gen
             else:

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -221,11 +221,10 @@ class SliceableIterable(object):
 
         if isinstance(key, slice):
             # if input is a slice, return another SliceableIterable
-            rel_indices = range(*key.indices(_len))
-            indices = _index_generator(rel_indices, abs_indices)
             start, stop, step = key.indices(_len)
-            # There is fenceposting subtlety in knowing the length of a slice.
-            new_length = 1 + (stop - start - 1) // step
+            rel_indices = range(start, stop, step)
+            new_length = len(rel_indices)
+            indices = _index_generator(rel_indices, abs_indices)
             return SliceableIterable(self._ancestor, indices, new_length)
         elif isinstance(key, collections.Iterable):
             # if the input is an iterable, doing 'fancy' indexing

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -138,6 +138,9 @@ class SliceableIterable(object):
     def __init__(self, ancestor, indices, length):
         """A generator that support fancy indexing, returning another generator
 
+        Also, this retains the attributes of the "ancestor" object that
+        created it.
+
         Parameters
         ----------
         ancestor : object
@@ -164,12 +167,18 @@ class SliceableIterable(object):
         # slicing impossible.
         >>> v3 = v2((i for i in [0]))  # argument is a generator
         >>> type(v3)
-        UnsliceableIterable
+        generator
         """
         self._len = length
         self._ancestor = ancestor
         self._indices = indices
         self._counter = 0
+
+    def __repr__(self):
+        msg = "Sliced Subsection of {0}. Original repr:\n".format(
+                type(self._ancestor).__name__)
+        old = '\n'.join("    " + ln for ln in repr(self._ancestor).split('\n'))
+        return msg + old
 
     def __iter__(self):
         # Advancing indices won't affect this new copy of self._indices.
@@ -178,6 +187,11 @@ class SliceableIterable(object):
 
     def __len__(self):
         return self._len
+
+    def __getattr__(self, key):
+        # Remember this only gets called if __getattribute__ raises an
+        # AttributeError. Try the ancestor object.
+        return getattr(self._ancestor, key)
 
     def __getitem__(self, key):
         """for data access"""

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -137,7 +137,11 @@ Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
 class SliceableIterable(object):
 
     def __init__(self, ancestor, indices, length=None):
-        """A generator that support fancy indexing, returning another generator
+        """A generator that supports fancy indexing
+
+        When sliced using any iterable with a known length, it return another
+        object like itself, a SliceableIterable. When sliced with an integer,
+        it returns the data payload.
 
         Also, this retains the attributes of the "ancestor" object that
         created it.

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -172,6 +172,7 @@ class SliceableIterable(object):
         self._counter = 0
 
     def __iter__(self):
+        # Advancing indices won't affect this new copy of self._indices.
         indices, self._indices = itertools.tee(self._indices)
         return (self._ancestor[i] for i in indices)
 
@@ -212,7 +213,7 @@ class SliceableIterable(object):
                 new_length = len(self._indices)
             except TypeError:
                 # The key is a generator; return a plain old generator.
-                # Without knowing the length, we can't give a SliceableIterable.
+                # Without knowing the length, we can't give a SliceableIterable
                 gen = (self[_k if _k >= 0 else _len + _k] for _k in key)
                 return gen
             else:

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -508,4 +508,12 @@ def pipeline(func):
             # Fall back on normal behavior of func, interpreting input
             # as a single image.
             return func(img_or_iterable)
+
+    if process.__doc__ is None:
+        process.__doc__ = ''
+    process.__doc__ = ("This function has been made pims-aware. When passed\n"
+                       "a pims reader or SliceableIterable, it will return a \n"
+                       "new SliceableIterable of the results. When passed \n"
+                       "other objects, its behavior is "
+                       "unchanged.\n\n") + process.__doc__
     return process

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -152,9 +152,9 @@ class SliceableIterable(object):
             must support __getitem__ with an integer argument
         indices : iterable
             giving indices into `ancestor`
-        length: integer
+        length : integer, optional
             length of indicies
-            This must be given explicitly if indices is a generator,
+            This is required if `indices` is a generator,
             that is, if `len(indices)` is invalid
 
         Examples

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -206,8 +206,7 @@ class SliceableIterable(object):
         try:
             # Advancing abs_indices won't affect this new copy of
             # self._ancestor._indices.
-            abs_indices, self._ancestor._indices = itertools.tee(
-                    self._ancestor._indices)
+            abs_indices, self._indices = itertools.tee(self._indices)
         except AttributeError:
             abs_indices = range(len(self._ancestor))
 
@@ -253,8 +252,8 @@ class SliceableIterable(object):
                 key = key if key >= 0 else _len + key
                 rel_indices, self._indices = itertools.tee(self._indices)
                 for _, i in zip(range(key + 1), rel_indices):
-                    new_key = i
-            return self._ancestor[new_key]
+                    abs_key = i
+            return self._ancestor[abs_key]
 
     def close(self):
         "Closing this child slice of the original reader does nothing."

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -180,16 +180,20 @@ class TestRecursiveSlicing(unittest.TestCase):
     def test_slice_of_slice(self):
         slice1 = self.v[4:]
         compare_slice_to_list(slice1, list('efghij'))
-        slice1a = self.v[3:]
-        compare_slice_to_list(slice1a, list('defghij'))
         slice2 = slice1[-3:]
         compare_slice_to_list(slice2, list('hij'))
+        slice1a = self.v[[3, 4, 5, 6, 7, 8, 9]]
+        compare_slice_to_list(slice1a, list('defghij'))
+        slice2a = slice1a[::2]
+        compare_slice_to_list(slice2a, list('dfhj'))
 
     def test_slice_of_slice_of_slice(self):
         slice1 = self.v[4:]
         compare_slice_to_list(slice1, list('efghij'))
         slice2 = slice1[1:-1]
         compare_slice_to_list(slice2, list('fghi'))
+        slice2a = slice1[[2, 3, 4]]
+        compare_slice_to_list(slice2a, list('ghi'))
         slice3 = slice2[1::2]
         compare_slice_to_list(slice3, list('gi'))
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -186,6 +186,22 @@ class TestRecursiveSlicing(unittest.TestCase):
         compare_slice_to_list(slice1a, list('defghij'))
         slice2a = slice1a[::2]
         compare_slice_to_list(slice2a, list('dfhj'))
+        slice2b = slice1a[::-1]
+        compare_slice_to_list(slice2b, list('jihgfed'))
+        slice2c = slice1a[::-2]
+        compare_slice_to_list(slice2c, list('jhfd'))
+        print('slice2d')
+        slice2d = slice1a[:0:-1]
+        compare_slice_to_list(slice2d, list('jihgfe'))
+        slice2e = slice1a[-1:1:-1]
+        compare_slice_to_list(slice2e, list('jihgf'))
+        slice2f = slice1a[-2:1:-1]
+        compare_slice_to_list(slice2f, list('ihgf'))
+        slice2g = slice1a[::-3]
+        compare_slice_to_list(slice2g, list('jgd'))
+        slice2h = slice1a[[5, 6, 2, -1, 3, 3, 3, 0]]
+        compare_slice_to_list(slice2h, list('ijfjgggd'))
+
 
     def test_slice_of_slice_of_slice(self):
         slice1 = self.v[4:]
@@ -215,8 +231,14 @@ class TestRecursiveSlicing(unittest.TestCase):
         compare_slice_to_list(slice2, list('cegi'))
         slice3 = slice2[:]
         compare_slice_to_list(slice3, list('cegi'))
+        print('define slice4')
         slice4 = slice3[:-1]
+        print('compare slice4')
         compare_slice_to_list(slice4, list('ceg'))
+        print('define slice4a')
+        slice4a = slice3[::-1]
+        print('compare slice4a')
+        compare_slice_to_list(slice4a, list('igec'))
 
     def test_slice_with_generator(self):
         slice1 = self.v[1:]


### PR DESCRIPTION
PIMS readers have always supported random access, and slicing on them has always returned a generator, lazily loading the image data. Like all Python generators, this generator has no length, cannot be sliced on, and can only be traversed one time. Reminder example:

```
>>> images = ImageSequence(...)
>>> images[5]  # works
>>> list(images)  # works
>>> list(images)  # works again
>>> my_slice = images[:8]  # this is a generator
>>> my_slice[5]  # not allowed
>>> list(my_slice)  # works once, but not again
```

In this PR, slicing on a PIMS reader returns a new object. The objecct behaves more like the reader that spawned it. That is, `my_slice` itself becomes sliceable, and it can be traversed multiple times. It also knows its length.

I'll use a cute demo reader, using letters of the alphabet instead of actual images, to succinctly show the new behavior.

```
In [3]: class DemoReader(pims.ImageSequence):
    def imread(self, filename, **kwargs):
        return np.array([[filename]])
   ...:     

```

The original reader object is sliceable the same as it always has been.

```
In [4]: images = DemoReader(list('abcdefghij'))

In [5]: images[0]
Out[5]: 
Frame([['a']], 
      dtype='|S1')

In [6]: len(images)
Out[6]: 10

In [7]: list(images)
Out[7]: 
[Frame([['a']], 
       dtype='|S1'), Frame([['b']], 
       dtype='|S1'), Frame([['c']], 
       dtype='|S1'), Frame([['d']], 
       dtype='|S1'), Frame([['e']], 
       dtype='|S1'), Frame([['f']], 
       dtype='|S1'), Frame([['g']], 
       dtype='|S1'), Frame([['h']], 
       dtype='|S1'), Frame([['i']], 
       dtype='|S1'), Frame([['j']], 
       dtype='|S1')]

In [8]: list(images)
Out[8]: 
[Frame([['a']], 
       dtype='|S1'), Frame([['b']], 
       dtype='|S1'), Frame([['c']], 
       dtype='|S1'), Frame([['d']], 
       dtype='|S1'), Frame([['e']], 
       dtype='|S1'), Frame([['f']], 
       dtype='|S1'), Frame([['g']], 
       dtype='|S1'), Frame([['h']], 
       dtype='|S1'), Frame([['i']], 
       dtype='|S1'), Frame([['j']], 
       dtype='|S1')]
```

But now slicing on `images` returns an object that can be listed more than once...
```
In [9]: slice1 = images[:8]

In [10]: list(slice1)
Out[10]: 
[Frame([['a']], 
       dtype='|S1'), Frame([['b']], 
       dtype='|S1'), Frame([['c']], 
       dtype='|S1'), Frame([['d']], 
       dtype='|S1'), Frame([['e']], 
       dtype='|S1'), Frame([['f']], 
       dtype='|S1'), Frame([['g']], 
       dtype='|S1'), Frame([['h']], 
       dtype='|S1')]

In [11]: list(slice1)
Out[11]: 
[Frame([['a']], 
       dtype='|S1'), Frame([['b']], 
       dtype='|S1'), Frame([['c']], 
       dtype='|S1'), Frame([['d']], 
       dtype='|S1'), Frame([['e']], 
       dtype='|S1'), Frame([['f']], 
       dtype='|S1'), Frame([['g']], 
       dtype='|S1'), Frame([['h']], 
       dtype='|S1')]

```

...and is recursively sliceable! o_O

```
In [13]: slice2 = slice1[::2]

In [14]: list(slice2)
Out[14]: 
[Frame([['a']], 
       dtype='|S1'), Frame([['c']], 
       dtype='|S1'), Frame([['e']], 
       dtype='|S1'), Frame([['g']], 
       dtype='|S1')]
```

The iterators behind these various slices are independent. They do not interfere with each other. (Listing `images` still works....)

```
In [15]: list(images)
Out[15]: 
[Frame([['a']], 
       dtype='|S1'), Frame([['b']], 
       dtype='|S1'), Frame([['c']], 
       dtype='|S1'), Frame([['d']], 
       dtype='|S1'), Frame([['e']], 
       dtype='|S1'), Frame([['f']], 
       dtype='|S1'), Frame([['g']], 
       dtype='|S1'), Frame([['h']], 
       dtype='|S1'), Frame([['i']], 
       dtype='|S1'), Frame([['j']], 
       dtype='|S1')]
```

No image is data is copied. The only caching involved in this is the caching of indices (frame numbers).

The tests pass, but I would like to add more tests before we merge. This reaches into the heart of PIMS and does some dizzying things with iterators. Please give it a spin!