### PR TITLE
ENH Multidimensional image base class

### DIFF
--- a/pims/api.py
+++ b/pims/api.py
@@ -12,7 +12,7 @@ import os
 from warnings import warn
 
 # has to be here for API stuff
-from pims.image_sequence import ImageSequence, ImageSequence3D  # noqa
+from pims.image_sequence import ImageSequence, ImageSequenceND  # noqa
 from .cine import Cine  # noqa
 from pims.tiff_stack import TiffStack_tifffile  # noqa
 

--- a/pims/api.py
+++ b/pims/api.py
@@ -59,7 +59,6 @@ else:
 try:
     import pims.bioformats
     if pims.bioformats.available():
-        BioformatsRaw = pims.bioformats.BioformatsReaderRaw
         Bioformats = pims.bioformats.BioformatsReader
     else:
         raise ImportError()

--- a/pims/api.py
+++ b/pims/api.py
@@ -1,7 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from pims.base_frames import FramesSequence, SliceableIterable, pipeline
+from pims.base_frames import (FramesSequence, FramesSequenceND,
+                              SliceableIterable, pipeline)
 from pims.frame import Frame
 from pims.display import (export, play, scrollable_stack, to_rgb, normalize,
                           plot_to_frame, plots_to_frame)

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -633,7 +633,7 @@ class FramesSequenceND(FramesSequence):
         as the order of `bundle_axes`.
         The last two elements have to be ['y', 'x'].
         """
-        return self._aggregate
+        return self._bundle_axes
 
     @bundle_axes.setter
     def bundle_axes(self, value):
@@ -655,7 +655,7 @@ class FramesSequenceND(FramesSequence):
         """ This determines which axes will be iterated over by the
         FramesSequence. The last element will iterate fastest.
         x and y are not allowed. """
-        return self._iterate_axes
+        return self._iter_axes
 
     @iter_axes.setter
     def iter_axes(self, value):

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -682,9 +682,9 @@ class Multidimensional(FramesSequence):
 
     @property
     def aggregate(self):
-        """ This determines which dimensions will be aggregated into one.
-        Frame. The dimensions in the ndarray that is returned by get_frame has
-        the same order as the order in this list. """
+        """ This determines which dimensions will be aggregated into one Frame.
+        The ndarray that is returned by get_frame has the same dimension order
+        as the order of aggregate. """
         return [d.name for d in self._dims if d.aggregate]
 
     @aggregate.setter
@@ -712,7 +712,7 @@ class Multidimensional(FramesSequence):
     @property
     def iterate(self):
         """ This determines which dimensions will be iterated over by the
-        FramesSequence. The last element in will iterate fastest. """
+        FramesSequence. The last element will iterate fastest. """
         return [d.name for d in self._dims if d.iterate]
 
     @iterate.setter
@@ -792,3 +792,4 @@ class Multidimensional(FramesSequence):
         for dim in self._dims:
             if key == dim.name:
                 return dim
+        raise AttributeError

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -629,8 +629,8 @@ class Multidimensional(FramesSequence):
     ...    def frame_shape_2D(self):
     ...        return self._frame_shape_2D
     ...    def __init__(self, shape, **dims):
-    ...        for name, size in dims.iteritems():
-    ...            self.add_dim(name, size)
+    ...        for name in dims:
+    ...            self.add_dim(name, dims[name])
     ...        self._frame_shape_2D = shape
     ...    def get_frame_2D(self, **ind):
     ...        return np.zeros(self.frame_shape_2D, dtype=self.pixel_type)
@@ -650,9 +650,6 @@ class Multidimensional(FramesSequence):
             self._dims = []
         new_dim = FramesDimension(name, size, aggregate, iterate, default)
         self._dims.append(new_dim)
-
-    def del_dim(self, name):
-        del self._dims[name]
 
     def __len__(self):
         return np.prod([d.size for d in self._dims if d.iterate])

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -694,6 +694,9 @@ class Multidimensional(FramesSequence):
         for dim_aggregate in value:
             if dim_aggregate.lower() in ['x', 'y']:
                 raise ValueError('Aggregate does not take dimensions x or y.')
+            if dim_aggregate not in self.dims:
+                raise ValueError(('Dimension named ''{}'' does not exist ' +
+                                  'in this image.').format(dim_aggregate))
 
         new_dims_aggr = [0] * len(value)
         new_dims_rest = []
@@ -719,6 +722,9 @@ class Multidimensional(FramesSequence):
         for dim_iterate in value:
             if dim_iterate.lower() in ['x', 'y']:
                 raise ValueError('Iterate does not take dimensions x or y.')
+            if dim_iterate not in self.dims:
+                raise ValueError(("Dimension named '{}' does not exist " +
+                                  "in this image.").format(dim_iterate))
 
         new_dims_iter = [0] * len(value)
         new_dims_rest = []
@@ -776,3 +782,10 @@ class Multidimensional(FramesSequence):
         # reshape the array into the desired shape
         result.shape = self.frame_shape
         return Frame(result, frame_no=i)
+
+    def __getattr__(self, key):
+        """ Enables dimensions to be called by for instance frames.c. Existing
+        methods always precede over this: a dimension named 'ndim' would not
+        be accessible by frames.ndim. """
+        if key in self.dims:
+            return self.dims[key]

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -564,17 +564,19 @@ class FramesSequenceND(FramesSequence):
         self._sizes = {}
         self._default_coords = {}
         self._iterate = []
-        self._aggregate = ['y', 'x']
+        self._aggregate = 'yx'
 
     def _dim_add(self, name, size, default=0):
         if not hasattr(self, '_sizes'):
             self._dim_init()
-        self._sizes[name] = size
+        if name in self._sizes:
+            raise ValueError("dimension '{}' already exists".format(name))
+        self._sizes[name] = int(size)
         if not (name == 'x' or name == 'y'):
-            self._default_coords[name] = default
+            self._default_coords[name] = int(default)
 
     def __len__(self):
-        return np.prod([self._sizes[d] for d in self._iterate])
+        return int(np.prod([self._sizes[d] for d in self._iterate]))
 
     @property
     def frame_shape(self):
@@ -656,7 +658,7 @@ class FramesSequenceND(FramesSequence):
 
         This method should take exactly one keyword argument per dimension,
         reflecting the index along each dimension. It returns a two dimensional
-        ndarray with shape `frame_shape_2D` and dtype `pixel_type`.
+        ndarray with shape (sizes['y'], sizes['x']) and dtype `pixel_type`.
         """
         pass
 

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -564,7 +564,7 @@ class FramesSequenceND(FramesSequence):
         self._sizes = {}
         self._default_coords = {}
         self._iterate = []
-        self._aggregate = 'yx'
+        self._aggregate = ['y', 'x']
 
     def _dim_add(self, name, size, default=0):
         if not hasattr(self, '_sizes'):
@@ -618,7 +618,7 @@ class FramesSequenceND(FramesSequence):
             if k in self._iterate:
                 del self._iterate[self._iterate.index(k)]
 
-        self._aggregate = value
+        self._aggregate = list(value)
 
     @property
     def iterate(self):
@@ -639,7 +639,7 @@ class FramesSequenceND(FramesSequence):
             if k in self._aggregate:
                 del self._aggregate[self._aggregate.index(k)]
 
-        self._iterate = value
+        self._iterate = list(value)
 
     @property
     def default_coords(self):

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -532,12 +532,43 @@ def pipeline(func):
 
 class FramesSequenceND(FramesSequence):
     """ A base class defining a FramesSequence with an arbitrary number of
-    dimensions. The properties `aggregate` and `iterate` define the functions
-    of each dimension.
+    dimensions. The properties `aggregate`, `iterate`, and `default_coords`
+    define the functions of each dimension. See below for a description of
+    each attribute.
 
-    Subclassed readers need to define `get_frame_2D`.
-    Dimensions need to be instanciated using the available method `add_dim`. It
+    Subclassed readers only need to define `get_frame_2D`, `pixel_type` and
+    `__init__`. In the `__init__`, at least dimensions y and x need to be
+    instanciated using `_dim_add(name, size)`.
+
+    The attributes `__len__`, `frame_shape`, and `get_frame` are defined by
+    this base_class; these are not meant to be changed.
+
+    Dimensions need to be instanciated using the available method `add_dim`.It
     is always necessary to specify the the dimensions `y` and `x`.
+
+    Attributes
+    ----------
+    dims : list of strings
+        List of all available dimensions
+    ndim : int
+        Number of image dimensions
+    sizes : dict of int
+        Dictionary with all dimension sizes
+    frame_shape : tuple of int
+        Shape of frames that will be returned by get_frame
+    iterate : iterable of strings
+        This determines which dimensions will be iterated over by the
+        FramesSequence. The last element in will iterate fastest.
+        x and y are not allowed.
+    aggregate : iterable of strings
+        This determines which dimensions will be aggregated into one Frame.
+        The dimensions in the ndarray that is returned by get_frame has
+        the same order as the order in this list. The last two elements have
+        to be ['y', 'x'].
+    default_coords: dict of int
+        When a dimension is not present in both iterate and aggregate, the
+        coordinate contained in this dictionary will be used.
+
 
     Examples
     --------
@@ -602,7 +633,8 @@ class FramesSequenceND(FramesSequence):
     def aggregate(self):
         """ This determines which dimensions will be aggregated into one Frame.
         The ndarray that is returned by get_frame has the same dimension order
-        as the order of aggregate. """
+        as the order of aggregate. The last two elements have to be ['y', 'x'].
+        """
         return self._aggregate
 
     @aggregate.setter
@@ -623,7 +655,8 @@ class FramesSequenceND(FramesSequence):
     @property
     def iterate(self):
         """ This determines which dimensions will be iterated over by the
-        FramesSequence. The last element will iterate fastest. """
+        FramesSequence. The last element will iterate fastest.
+        x and y are not allowed. """
         return self._iterate
 
     @iterate.setter
@@ -643,6 +676,8 @@ class FramesSequenceND(FramesSequence):
 
     @property
     def default_coords(self):
+        """ When a dimension is not present in both iterate and aggregate, the
+        coordinate contained in this dictionary will be used. """
         return self._default_coords
 
     @default_coords.setter

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -532,43 +532,41 @@ def pipeline(func):
 
 class FramesSequenceND(FramesSequence):
     """ A base class defining a FramesSequence with an arbitrary number of
-    dimensions. The properties `aggregate`, `iterate`, and `default_coords`
-    define the functions of each dimension. See below for a description of
+    axes. In the context of this reader base class, dimensions like 'x', 'y',
+    't' and 'z' will be called axes. Indices along these axes will be called
+    coordinates.
+
+    The properties `bundle_axes`, `iter_axes`, and `default_coords` define
+    to which coordinates each index points. See below for a description of
     each attribute.
 
     Subclassed readers only need to define `get_frame_2D`, `pixel_type` and
-    `__init__`. In the `__init__`, at least dimensions y and x need to be
-    instanciated using `_dim_add(name, size)`.
+    `__init__`. In the `__init__`, at least axes y and x need to be
+    initialized using `_init_axis(name, size)`.
 
     The attributes `__len__`, `frame_shape`, and `get_frame` are defined by
     this base_class; these are not meant to be changed.
 
-    Dimensions need to be instanciated using the available method `add_dim`.It
-    is always necessary to specify the the dimensions `y` and `x`.
-
     Attributes
     ----------
-    dims : list of strings
-        List of all available dimensions
+    axes : list of strings
+        List of all available axes
     ndim : int
-        Number of image dimensions
+        Number of image axes
     sizes : dict of int
-        Dictionary with all dimension sizes
+        Dictionary with all axis sizes
     frame_shape : tuple of int
         Shape of frames that will be returned by get_frame
-    iterate : iterable of strings
-        This determines which dimensions will be iterated over by the
-        FramesSequence. The last element in will iterate fastest.
-        x and y are not allowed.
-    aggregate : iterable of strings
-        This determines which dimensions will be aggregated into one Frame.
-        The dimensions in the ndarray that is returned by get_frame has
-        the same order as the order in this list. The last two elements have
-        to be ['y', 'x'].
+    iter_axes : iterable of strings
+        This determines which axes will be iterated over by the FramesSequence.
+        The last element in will iterate fastest. x and y are not allowed.
+    bundle_axes : iterable of strings
+        This determines which axes will be bundled into one Frame. The axes in
+        the ndarray that is returned by get_frame have the same order as the
+        order in this list. The last two elements have to be ['y', 'x'].
     default_coords: dict of int
-        When a dimension is not present in both iterate and aggregate, the
+        When a dimension is not present in both iter_axes and bundle_axes, the
         coordinate contained in this dictionary will be used.
-
 
     Examples
     --------
@@ -576,107 +574,106 @@ class FramesSequenceND(FramesSequence):
     ...    @property
     ...    def pixel_type(self):
     ...        return 'uint8'
-    ...    def __init__(self, shape, **dims):
-    ...        self._dim_add('y', shape[0])
-    ...        self._dim_add('x', shape[1])
-    ...        for name in dims:
-    ...            self._dim_add(name, dims[name])
+    ...    def __init__(self, shape, **axes):
+    ...        self._init_axis('y', shape[0])
+    ...        self._init_axis('x', shape[1])
+    ...        for name in axes:
+    ...            self._init_axis(name, axes[name])
     ...    def get_frame_2D(self, **ind):
     ...        return np.zeros((self.sizes['y'], self.sizes['x']),
     ...                        dtype=self.pixel_type)
 
     >>> frames = MDummy((64, 64), t=80, c=2, z=10, m=5)
-    >>> frames.aggregate = 'cz'
-    >>> frames.iterate = 't'
+    >>> frames.bundle_axes = 'czyx'
+    >>> frames.iter_axes = 't'
     >>> frames.default_coords['m'] = 3
     >>> frames[5]  # returns Frame at T=5, M=3 with shape (2, 10, 64, 64)
     """
-    def _dim_init(self):
-        self._sizes = {}
-        self._default_coords = {}
-        self._iterate = []
-        self._aggregate = ['y', 'x']
-
-    def _dim_add(self, name, size, default=0):
+    def _init_axis(self, name, size, default=0):
+        # check if the axes have been initialized, if not, do it here
         if not hasattr(self, '_sizes'):
-            self._dim_init()
-        if name in self._sizes:
+            self._sizes = {}
+            self._default_coords = {}
+            self._iter_axes = []
+            self._bundle_axes = ['y', 'x']
+        elif name in self._sizes:
             raise ValueError("dimension '{}' already exists".format(name))
         self._sizes[name] = int(size)
         if not (name == 'x' or name == 'y'):
-            self._default_coords[name] = int(default)
+            self.default_coords[name] = int(default)
 
     def __len__(self):
-        return int(np.prod([self._sizes[d] for d in self._iterate]))
+        return int(np.prod([self._sizes[d] for d in self._iter_axes]))
 
     @property
     def frame_shape(self):
         """ Returns the shape of the frame as returned by get_frame. """
-        return tuple([self._sizes[d] for d in self._aggregate])
+        return tuple([self._sizes[d] for d in self._bundle_axes])
 
     @property
-    def dims(self):
-        """ Returns a list of all dimensions. """
+    def axes(self):
+        """ Returns a list of all axes. """
         return [k for k in self._sizes]
 
     @property
     def ndim(self):
-        """ Returns the number of dimensions. """
+        """ Returns the number of axes. """
         return len(self._sizes)
 
     @property
     def sizes(self):
-        """ Returns a dict of all dimension sizes. """
+        """ Returns a dict of all axis sizes. """
         return self._sizes
 
     @property
-    def aggregate(self):
-        """ This determines which dimensions will be aggregated into one Frame.
+    def bundle_axes(self):
+        """ This determines which dimensions will be bundled into one Frame.
         The ndarray that is returned by get_frame has the same dimension order
-        as the order of aggregate. The last two elements have to be ['y', 'x'].
+        as the order of `bundle_axes`.
+        The last two elements have to be ['y', 'x'].
         """
         return self._aggregate
 
-    @aggregate.setter
-    def aggregate(self, value):
+    @bundle_axes.setter
+    def bundle_axes(self, value):
         invalid = [k for k in value if k not in self._sizes]
         if invalid:
-            raise ValueError("dimensions %r do not exist" % invalid)
+            raise ValueError("axes %r do not exist" % invalid)
 
         if len(value) < 2 or not (value[-1] == 'x' and value[-2] == 'y'):
-            raise ValueError("aggregate should end with ['y', 'x']")
+            raise ValueError("bundle_axes should end with ['y', 'x']")
 
         for k in value:
-            if k in self._iterate:
-                del self._iterate[self._iterate.index(k)]
+            if k in self._iter_axes:
+                del self._iter_axes[self._iter_axes.index(k)]
 
-        self._aggregate = list(value)
+        self._bundle_axes = list(value)
 
     @property
-    def iterate(self):
-        """ This determines which dimensions will be iterated over by the
+    def iter_axes(self):
+        """ This determines which axes will be iterated over by the
         FramesSequence. The last element will iterate fastest.
         x and y are not allowed. """
-        return self._iterate
+        return self._iterate_axes
 
-    @iterate.setter
-    def iterate(self, value):
+    @iter_axes.setter
+    def iter_axes(self, value):
         invalid = [k for k in value if k not in self._sizes]
         if invalid:
-            raise ValueError("dimensions %r do not exist" % invalid)
+            raise ValueError("axes %r do not exist" % invalid)
 
         if 'x' in value or 'y' in value:
-            raise ValueError("y and x cannot be iterated over")
+            raise ValueError("axes 'y' and 'x' cannot be iterated")
 
         for k in value:
-            if k in self._aggregate:
-                del self._aggregate[self._aggregate.index(k)]
+            if k in self._bundle_axes:
+                del self._bundle_axes[self._bundle_axes.index(k)]
 
-        self._iterate = list(value)
+        self._iter_axes = list(value)
 
     @property
     def default_coords(self):
-        """ When a dimension is not present in both iterate and aggregate, the
+        """ When a axis is not present in both iter_axes and bundle_axes, the
         coordinate contained in this dictionary will be used. """
         return self._default_coords
 
@@ -684,36 +681,36 @@ class FramesSequenceND(FramesSequence):
     def default_coords(self, value):
         invalid = [k for k in value if k not in self._sizes]
         if invalid:
-            raise ValueError("dimensions %r do not exist" % invalid)
+            raise ValueError("axes %r do not exist" % invalid)
         self._default_coords.update(**value)
 
     @abstractmethod
     def get_frame_2D(self, **ind):
         """ The actual frame reader, defined by the subclassed reader.
 
-        This method should take exactly one keyword argument per dimension,
-        reflecting the index along each dimension. It returns a two dimensional
+        This method should take exactly one keyword argument per axis,
+        reflecting the coordinate along each axis. It returns a two dimensional
         ndarray with shape (sizes['y'], sizes['x']) and dtype `pixel_type`. It
         may also return a Frame object, so that metadata will be propagated.
         """
         pass
 
     def get_frame(self, i):
-        """ Returns a Frame of shape deterimend by aggregate. The index value
-        is interpreted according to the `iterate` property. Coordinates not
-        present in both `iterate` and `aggregate` will be set to their default
-        value (see `default_coords`). """
+        """ Returns a Frame of shape deterimend by bundle_axes. The index value
+        is interpreted according to the iter_axes property. Coordinates not
+        present in both iter_axes and bundle_axes will be set to their default
+        value (see default_coords). """
 
         # start with the default coordinates
         coords = self._default_coords.copy()
 
         # list sizes of iterate dimensions
-        iter_sizes = [self._sizes[k] for k in self._iterate]
+        iter_sizes = [self._sizes[k] for k in self._iter_axes]
         # list how much i has to increase to get an increase of coordinate n
         iter_cumsizes = np.append(np.cumprod(iter_sizes[::-1])[-2::-1], 1)
         # calculate the coordinates and update the coords dictionary
         iter_coords = (i // iter_cumsizes) % iter_sizes
-        coords.update(**{k: v for k, v in zip(self._iterate, iter_coords)})
+        coords.update(**{k: v for k, v in zip(self._iter_axes, iter_coords)})
 
         shape = self.frame_shape
         if len(shape) == 2:  # simple case of only one frame
@@ -734,7 +731,7 @@ class FramesSequenceND(FramesSequence):
                 result[n] = frame
                 if hasattr(frame, 'metadata'):
                     mdlist.append(frame.metadata)
-                for dim in self._aggregate[-3::-1]:
+                for dim in self._bundle_axes[-3::-1]:
                     coords[dim] += 1
                     if coords[dim] >= self._sizes[dim]:
                         coords[dim] = 0

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -590,13 +590,16 @@ class FramesSequenceND(FramesSequence):
     >>> frames.default_coords['m'] = 3
     >>> frames[5]  # returns Frame at T=5, M=3 with shape (2, 10, 64, 64)
     """
+    def _clear_axes(self):
+        self._sizes = {}
+        self._default_coords = {}
+        self._iter_axes = []
+        self._bundle_axes = ['y', 'x']
+
     def _init_axis(self, name, size, default=0):
         # check if the axes have been initialized, if not, do it here
         if not hasattr(self, '_sizes'):
-            self._sizes = {}
-            self._default_coords = {}
-            self._iter_axes = []
-            self._bundle_axes = ['y', 'x']
+            self._clear_axes()
         elif name in self._sizes:
             raise ValueError("dimension '{}' already exists".format(name))
         self._sizes[name] = int(size)
@@ -703,6 +706,8 @@ class FramesSequenceND(FramesSequence):
         is interpreted according to the iter_axes property. Coordinates not
         present in both iter_axes and bundle_axes will be set to their default
         value (see default_coords). """
+        if i > len(self):
+            raise IndexError('index out of range')
 
         # start with the default coordinates
         coords = self._default_coords.copy()

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -493,7 +493,8 @@ class BioformatsReader(FramesSequenceND):
         _coords.update(coords)
         if self.isRGB:
             _coords['c'] = 0
-        j = self.rdr.getIndex(_coords['z'], _coords['c'], _coords['t'])
+        j = self.rdr.getIndex(int(_coords['z']), int(_coords['c']),
+                              int(_coords['t']))
         if self.read_mode == 'jpype':
             im = np.frombuffer(self.rdr.openBytes(j)[:],
                                dtype=self._pixel_type)

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -164,8 +164,8 @@ class MetadataRetrieve(object):
                         return (lambda *args: wrap_md(fn1, naame,
                                                       paramcount, *args))
                     fnw = fnw()
-                    fnw.__doc__ = ('loci.formats.meta.MetadataRetrieve.'
-                                   + name + ' wrapped\nby JPype and an '
+                    fnw.__doc__ = ('loci.formats.meta.MetadataRetrieve.' +
+                                   name + ' wrapped\nby JPype and an '
                                    'additional automatic typeconversion.\n\n')
                     setattr(self, name[3:], fnw)
                     continue
@@ -177,399 +177,19 @@ class MetadataRetrieve(object):
         listing = list(filter(lambda x: x[:2] != '__', dir(self)))
         return '<MetadataRetrieve> Available loci.formats.meta.' + \
                'MetadataRetrieve functions: ' + ', '.join(listing)
-               
-class BioformatsReaderRaw(FramesSequence):
-    """Reads 2D images from the frames of a file supported by bioformats into
-    an iterable object that returns images as numpy arrays.
-
-    Parameters
-    ----------
-    filename : str
-    process_func : function, optional
-        callable with signature `proc_img = process_func(img)`,
-        which will be applied to the data from each frame
-    dtype : numpy datatype, optional
-        Image arrays will be converted to this datatype.
-    as_grey : boolean, optional
-        Convert color images to greyscale. False by default.
-        May not be used in conjunction with process_func.
-    meta : bool, optional
-        When true, the metadata object is generated. Takes time to build.
-    java_memory : str, optional
-        The max heap size of the java virtual machine, default 512m. As soon as
-        the virtual machine is started, python has to be restarted to change
-        the max heap size.
-    read_mode : {'auto', 'jpype', 'stringbuffer', 'javacasting'}
-        JPype can automatically convert java arrays to numpy arrays. On some
-        installations, this will not work. In this case, using a Stringbuffer
-        is the preferred option. However this doesn't work on Py3 and Unix
-        systems. In that case, java can cast the type. Default 'auto'.
-    series: int, optional
-        Active image series index, defaults to 0. Changeable via the `series`
-        property.
 
 
-    Attributes
-    ----------
-    __len__ : int
-        Number of planes in active series (= size Z*C*T)
-    metadata : MetadataRetrieve object
-        This object contains loci.formats.meta.MetadataRetrieve functions for
-        metadata reading. Not available when meta == False.
-    frame_metadata : dict
-        This dictionary sets which metadata fields are read and passed into the
-        Frame.metadata field obtained by get_frame. This will only work if
-        meta=True. Only MetadataRetrieve methods with signature (series, plane)
-        will be accepted.
-    sizes : dict of int
-        Number of series and for active series: X, Y, Z, C, T sizes
-    frame_shape : tuple of int
-        Shape of the image (y, x) or (y, x, 3) or (y, x, 4)
-    series : int
-        active series that is read by get_frame. Writeable.
-    channel : int or list of int
-        channel(s) that are read by get_frame. Writeable.
-    pixel_type : numpy.dtype
-        numpy datatype of pixels
-    isRGB : boolean
-        True if the image is an RGB image
-    read_mode : {'auto', 'jpype', 'stringbuffer', 'javacasting'}
-        See parameter
-
-    Methods
-    ----------
-    get_frame(plane) : pims.frame object
-        returns 2D image in active series. See notes for metadata content.
-    get_index(z, c, t) : int
-        returns the imageindex in the current series with given coordinates
-    get_metadata_raw(form) : dict or list or string
-        returns the raw metadata from the file. Form defaults to 'dict', other
-        options are 'list' and 'string'.
-    close() :
-        closes the reader
-
-    Examples
-    ----------
-    >>> frames.metadata.PlaneDeltaT(0, 50)
-    ...    # evaluates loci.formats.meta.MetadataRetrieve.getPlaneDeltaT(0, 50)
-
-    Notes
-    ----------
-    It is not necessary to shutdown the JVM at end. This will be automatically
-    done when JPype is unloaded at python exit.
-
-    Dependencies:
-    https://pypi.python.org/pypi/JPype1
-
-    Tested with files from http://loci.wisc.edu/software/sample-data
-    Working for:
-        Zeiss Laser Scanning Microscopy, IPLab, Gatan Digital Micrograph,
-        Image-Pro sequence, Leica, Image-Pro workspace, Nikon NIS-Elements ND2,
-        Image Cytometry Standard, QuickTime movie, Olympus Fluoview TIFF,
-        Andor Bio-imaging Division TIFF, PerkinElmer, Leica LIF
-
-    Bio-Rad PIC and Openlab LIFF can only be loaded as single frames
-
-    For files larger than 4GB, 64 bits Python is required
-
-    Metadata automatically provided by get_frame, as dictionary:
-        plane: index of image in series
-        series: series index
-        indexC, indexZ, indexT: indexes of C, Z, T
-        X, Y, Z: physical location of the image in microns
-        T: timestamp of the image in seconds
-    """
-
-    @classmethod
-    def class_exts(cls):
-        try:
-            return {'.lsm', '.ipl', '.dm3', '.seq', '.nd2', '.ics', '.ids',
-                    '.mov', '.ipw', '.tif', '.tiff', '.jpg', '.bmp', '.lif'}
-        except AttributeError:
-            return {}
-
-    class_priority = 2
-
-    def __init__(self, filename, process_func=None, dtype=None, as_grey=False,
-                 meta=True, java_memory='512m', read_mode='auto', series=0):
-        global loci
-
-        if read_mode not in ['auto', 'jpype', 'stringbuffer', 'javacasting']:
-            raise ValueError('Invalid read_mode value.')
-
-        # Make sure that file exists before starting java
-        if not os.path.isfile(filename):
-            raise IOError('The file "{}" does not exist.'.format(filename))
-
-        # Start java VM and initialize logger (globally)
-        if not jpype.isJVMStarted():
-            loci_path = _find_jar()
-            jpype.startJVM(jpype.getDefaultJVMPath(), '-ea',
-                           '-Djava.class.path=' + loci_path,
-                           '-Xmx' + java_memory)
-            log4j = jpype.JPackage('org.apache.log4j')
-            log4j.BasicConfigurator.configure()
-            log4j_logger = log4j.Logger.getRootLogger()
-            log4j_logger.setLevel(log4j.Level.ERROR)
-
-        if not jpype.isThreadAttachedToJVM():
-            jpype.attachThreadToJVM()
-
-        loci = jpype.JPackage('loci')
-
-        # Initialize reader and metadata
-        self.filename = str(filename)
-        self.rdr = loci.formats.ChannelSeparator(loci.formats.ChannelFiller())
-        if meta:
-            self._metadata = loci.formats.MetadataTools.createOMEXMLMetadata()
-            self.rdr.setMetadataStore(self._metadata)
-        self.rdr.setId(self.filename)
-
-        # Checkout reader dtype and define read mode
-        isLittleEndian = self.rdr.isLittleEndian()
-        LE_prefix = ['>', '<'][isLittleEndian]
-        FormatTools = loci.formats.FormatTools
-        self._dtype_dict = {FormatTools.INT8: 'i1',
-                            FormatTools.UINT8: 'u1',
-                            FormatTools.INT16: LE_prefix + 'i2',
-                            FormatTools.UINT16: LE_prefix + 'u2',
-                            FormatTools.INT32: LE_prefix + 'i4',
-                            FormatTools.UINT32: LE_prefix + 'u4',
-                            FormatTools.FLOAT: LE_prefix + 'f4',
-                            FormatTools.DOUBLE: LE_prefix + 'f8'}
-        self._dtype_dict_java = {}
-        for loci_format in self._dtype_dict.keys():
-            self._dtype_dict_java[loci_format] = \
-                (FormatTools.getBytesPerPixel(loci_format),
-                 FormatTools.isFloatingPoint(loci_format),
-                 isLittleEndian)
-
-        # Set the correct series and initialize the sizes
-        self._size_series = self.rdr.getSeriesCount()
-        if series >= self._size_series or series < 0:
-            self.rdr.close()
-            raise IndexError('Series index out of bounds.')
-        self._series = series
-        self._forced_dtype = dtype
-        self._change_series()
-
-        # Set read mode. When auto, tryout fast and check the image size.
-        if read_mode == 'auto':
-            Jarr = self.rdr.openBytes(0)
-            if isinstance(Jarr[:], np.ndarray):
-                read_mode = 'jpype'
-            else:
-                warn('JPype numpy conversion is not installed properly. '
-                     'Falling back to slower read modes.')
-                try:
-                    im = self._jbytearr_stringbuffer(Jarr)
-                    im.reshape(self._sizeRGB, self._sizeX, self._sizeY)
-                except (AttributeError, ValueError):
-                    read_mode = 'javacasting'
-                else:
-                    read_mode = 'stringbuffer'
-        self.read_mode = read_mode
-
-        # Define a process func, if applicable
-        # TODO: check if as grey works with series with different dimensions
-        self._validate_process_func(process_func)
-        self._as_grey(as_grey, process_func)
-
-        # Define the names of the standard per frame metadata.
-        self.frame_metadata = {}
-        if meta:
-            self.metadata = MetadataRetrieve(self._metadata)
-            if hasattr(self.metadata, 'PlaneTheT'):
-                self.frame_metadata['indexT'] = 'PlaneTheT'
-            if hasattr(self.metadata, 'PlaneTheZ'):
-                self.frame_metadata['indexZ'] = 'PlaneTheZ'
-            if hasattr(self.metadata, 'PlaneTheC'):
-                self.frame_metadata['indexC'] = 'PlaneTheC'
-            if hasattr(self.metadata, 'PlaneDeltaT'):
-                self.frame_metadata['T'] = 'PlaneDeltaT'
-            if hasattr(self.metadata, 'PlanePositionX'):
-                self.frame_metadata['X'] = 'PlanePositionX'
-            if hasattr(self.metadata, 'PlanePositionY'):
-                self.frame_metadata['Y'] = 'PlanePositionY'
-            if hasattr(self.metadata, 'PlanePositionZ'):
-                self.frame_metadata['Z'] = 'PlanePositionZ'
-
-    def _change_series(self):
-        """Changes series and rereads dtype, sizes and pixelsizes.
-        When pixelsize Y is not found, pixels are assumed to be square.
-        """
-        series = self._series
-        self.rdr.setSeries(series)
-        self.isRGB = self.rdr.isRGB()
-        self._sizeRGB = self.rdr.getRGBChannelCount()
-        self._isInterleaved = self.rdr.isInterleaved()
-        self._sizeT = self.rdr.getSizeT()
-        self._sizeZ = self.rdr.getSizeZ()
-        self._sizeY = self.rdr.getSizeY()
-        self._sizeX = self.rdr.getSizeX()
-        if self.isRGB:
-            self._sizeC = 1
-            self._first_frame_shape = (self._sizeY, self._sizeX, self._sizeRGB)
-        else:
-            self._sizeC = self.rdr.getSizeC()
-            self._first_frame_shape = (self._sizeY, self._sizeX)
-        self._planes = self.rdr.getImageCount()
-
-        # determine pixel type
-        pixel_type = self.rdr.getPixelType()
-        dtype = self._dtype_dict[pixel_type]
-        java_dtype = self._dtype_dict_java[pixel_type]
-
-        self._jbytearr_stringbuffer = \
-            lambda arr: _jbytearr_stringbuffer(arr, dtype)
-        self._jbytearr_javacasting = \
-            lambda arr: _jbytearr_javacasting(arr, dtype, *java_dtype)
-        self._source_dtype = dtype
-
-        if self._forced_dtype is None:
-            self._pixel_type = self._source_dtype
-        else:
-            self._pixel_type = self._forced_dtype
-
-    def __len__(self):
-        return self._planes
-
-    def close(self):
-        self.rdr.close()
-
-    def __del__(self):
-        self.close()
-
-    @property
-    def sizes(self):
-        return {'series': self._size_series, 'X': self._sizeX,
-                'Y': self._sizeY, 'Z': self._sizeZ, 'C': self._sizeC,
-                'T': self._sizeT}
-
-    @property
-    def series(self):
-        return self._series
-
-    @series.setter
-    def series(self, value):
-        if value >= self._size_series or value < 0:
-            raise IndexError('Series index out of bounds.')
-        else:
-            if value != self._series:
-                self._series = value
-                self._change_series()
-
-    @property
-    def frame_shape(self):
-        return self._first_frame_shape
-
-    def get_frame(self, j):
-        """Returns image in current series specific as a Frame object with
-        specified frame_no and metadata attributes.
-        """
-        im, metadata = self._get_frame(self.series, j)
-        return Frame(self.process_func(im), frame_no=j, metadata=metadata)
-
-    def _get_frame(self, series, j):
-        """Actual reader, returns image as 2D numpy array and metadata as
-        dict. It changes the series property if necessary.
-        """
-        self.series = series  # use property setter & error reporting
-
-        if self.read_mode == 'jpype':
-            im = np.frombuffer(self.rdr.openBytes(j)[:],
-                               dtype=self._source_dtype)
-        elif self.read_mode == 'stringbuffer':
-            im = self._jbytearr_stringbuffer(self.rdr.openBytes(j))
-        elif self.read_mode == 'javacasting':
-            im = self._jbytearr_javacasting(self.rdr.openBytes(j))
-
-        if self.isRGB:
-            if self._isInterleaved:
-                im.shape = (self._sizeY, self._sizeX, self._sizeRGB)
-            else:
-                im.shape = (self._sizeRGB, self._sizeY, self._sizeX)
-                im = im.transpose(1, 2, 0)  # put RGB in inner dimension
-        else:
-            im.shape = (self._sizeY, self._sizeX)
-
-        im = im.astype(self._pixel_type, copy=False)
-
-        metadata = {'frame': j, 'series': series}
-        for key, method in self.frame_metadata.items():
-            metadata[key] = getattr(self.metadata, method)(series, j)
-
-        return im, metadata
-
-    def get_metadata_raw(self, form='dict'):
-        hashtable = self.rdr.getGlobalMetadata()
-        keys = hashtable.keys()
-        if form == 'dict':
-            result = {}
-            while keys.hasMoreElements():
-                key = keys.nextElement()
-                result[key] = _maybe_tostring(hashtable.get(key))
-        elif form == 'list':
-            result = []
-            while keys.hasMoreElements():
-                key = keys.nextElement()
-                result.append(key + ': ' + _maybe_tostring(hashtable.get(key)))
-        elif form == 'string':
-            result = u''
-            while keys.hasMoreElements():
-                key = keys.nextElement()
-                result += key + ': ' + _maybe_tostring(hashtable.get(key)) + '\n'
-        return result
-
-    def get_index(self, z, c, t):
-        return self.rdr.getIndex(z, c, t)
-
-    @property
-    def reader_class_name(self):
-        return self.rdr.getFormat()
-
-    @property
-    def pixel_type(self):
-        return self._pixel_type
-
-    def __repr__(self):
-        result = """<Frames>
-Source: {filename}
-Series: {mp}, active: {mpa}
-Framecount: {count} frames
-Colordepth: {c}
-Zstack depth: {z}
-Time frames: {t}
-Frame Shape: {w} x {h}""".format(w=self._sizeX,
-                                 h=self._sizeY,
-                                 mp=self._size_series,
-                                 mpa=self._series,
-                                 count=self._planes,
-                                 z=self._sizeZ,
-                                 t=self._sizeT,
-                                 c=self._sizeC,
-                                 filename=self.filename)
-        return result
-
-
-class BioformatsReader(BioformatsReaderRaw):
+class BioformatsReader(FramesSequenceND):
     """Reads multidimensional images from the frames of a file supported by
-    bioformats into an iterable object that returns images as numpy arrays
-    indexed by t. The numpy array dimensions are CZYX, ZYX, CYX or YX,
-    depending on the contents of the file and the setting of the channel
-    property.
+    bioformats into an iterable object that returns images as numpy arrays.
+    The axes inside the numpy array (czyx, zyx, cyx or yx) depend on the
+    value of `bundle_axes`. It defaults to zyx or yx.
+
+    The iteration axis depends on `iter_axes`. It defaults to t.
 
     Parameters
     ----------
     filename: str
-    process_func : function, optional
-        callable with signature `proc_img = process_func(img)`,
-        which will be applied to the data from each frame
-    dtype : numpy datatype, optional
-        Image arrays will be converted to this datatype.
-    as_grey : boolean, optional
-        Convert color images to greyscale. False by default.
-        May not be used in conjunction with process_func.
     meta: bool, optional
         When true, the metadata object is generated. Takes time to build.
     java_memory : str, optional
@@ -584,14 +204,30 @@ class BioformatsReader(BioformatsReaderRaw):
     series: int, optional
         Active image series index, defaults to 0. Changeable via the `series`
         property.
-    C : int or list of int
-        Channel(s) that are read by get_frame. Changeable via the `channel`
-        property. Defaults to all channels.
 
     Attributes
     ----------
-    __len__ : int
-        Number of timepoints in active series (equal to sizes['T'])
+    axes : list of strings
+        List of all available axes
+    ndim : int
+        Number of image axes
+    sizes : dict of int
+        Dictionary with all axis sizes
+    size_series : int
+        Number of series inside file
+    frame_shape : tuple of int
+        Shape of frames that will be returned by get_frame
+    iter_axes : iterable of strings
+        This determines which axes will be iterated over by the FramesSequence.
+        The last element in will iterate fastest. x and y are not allowed.
+    bundle_axes : iterable of strings
+        This determines which axes will be bundled into one Frame. The axes in
+        the ndarray that is returned by get_frame have the same order as the
+        order in this list. The last two elements have to be ['y', 'x'].
+        Defaults to ['z', 'y', 'x'], when 'z' is available.
+    default_coords: dict of int
+        When a dimension is not present in both iter_axes and bundle_axes, the
+        coordinate contained in this dictionary will be used.
     metadata : MetadataRetrieve object
         This object contains loci.formats.meta.MetadataRetrieve functions for
         metadata reading. Not available when meta == False.
@@ -600,34 +236,30 @@ class BioformatsReader(BioformatsReaderRaw):
         Frame.metadata field obtained by get_frame. This will only work if
         meta=True. Only MetadataRetrieve methods with signature (series, plane)
         will be accepted.
-    sizes : dict of int
-        Number of series and for active series: X, Y, Z, C, T sizes
-    frame_shape : tuple of int
-        Shape of the image (y, x) or (y, x, 3) or (y, x, 4)
-    channel : int or iterable of int
-        channel(s) that are read by get_frame. Writeable.
     series : int
         active series that is read by get_frame. Writeable.
-    channel : int or list of int
-        channel(s) that are read by get_frame. Writeable.
     pixel_type : numpy.dtype
         numpy datatype of pixels
     java_log : string
         contains everything printed to java system.out and system.err
     isRGB : boolean
         True if the image is an RGB image
+    isInterleaved : boolean
+        True if the image is interleaved
     read_mode : {'auto', 'jpype', 'stringbuffer', 'javacasting'}
         See parameter
-    channel_RGB : list of rgb values (floats)
+    colors : list of rgb values (floats)
         The rgb values of all active channels set by the channels property. If
-        not supported by the underlying reader, this returns an empty list
+        not supported by the underlying reader, this returns None
+    calibration : float
+        The pixel size in microns per pixel, in x/y direction
+    calibrationZ : float
+        The pixel size in microns per pixel, in z direction
+    reader_class_name : string
+        The name of the used Bioformats reader
 
     Methods
     ----------
-    get_frame(plane) : pims.frame object
-        returns 3D image in active series. See notes for metadata content.
-    get_index(z, c, t) : int
-        returns the imageindex in the current series with given coordinates
     get_metadata_raw(form) : dict or list or string
         returns the raw metadata from the file. Form defaults to 'dict', other
         options are 'list' and 'string'.
@@ -661,317 +293,257 @@ class BioformatsReader(BioformatsReaderRaw):
     Metadata automatically provided by get_frame, as dictionary:
         plane: index of image in series
         series: series index
-        indexC, indexZ, indexT: indexes of C, Z, T
-        X, Y, Z: physical location of the image in microns
-        T: timestamp of the image in seconds
+        c, z, t: indexes of C, Z, T
+        x_um, y_um, z_um: physical location of the image in microns
+        t_s: timestamp of the image in seconds
     """
+    @classmethod
+    def class_exts(cls):
+        try:
+            return {'.lsm', '.ipl', '.dm3', '.seq', '.nd2', '.ics', '.ids',
+                    '.mov', '.ipw', '.tif', '.tiff', '.jpg', '.bmp', '.lif'}
+        except AttributeError:
+            return {}
+
     class_priority = 5
 
-    def __init__(self, filename, process_func=None, dtype=None, as_grey=False,
-                 meta=True, java_memory='512m', read_mode='auto', series=0,
-                 C=None):
-        self._channel = C
-        super(BioformatsReader, self).__init__(filename, process_func, dtype,
-                                               as_grey, meta, java_memory,
-                                               read_mode, series)
-        rgbvalues = []
-        try:
-            for c in range(self._sizeC):
-                rgba = self.metadata.ChannelColor(self.series, c)
-                rgbvalues.append([(rgba >> 24 & 255) / 255,
-                                  (rgba >> 16 & 255) / 255,
-                                  (rgba >> 8 & 255) / 255])
-        except:  # a lot could happen, use catch all here
-            self.channel_RGB_all = []
-        else:
-            self.channel_RGB_all = rgbvalues
-
-    def __len__(self):
-        return self._sizeT
-
     @property
-    def channel(self):
-        if self.isRGB:
-            raise AttributeError('Channel index not applicable to RGB files.')
-        return self._channel
+    def pixel_type(self):
+        return self._pixel_type
 
-    @channel.setter
-    def channel(self, value):
-        if self.isRGB:
-            raise AttributeError('Channel index not applicable to RGB files.')
-        try:
-            channel = tuple(value)
-        except TypeError:
-            channel = (value,)
-        if np.any(np.greater_equal(channel, self._sizeC)) or \
-           np.any(np.less(channel, 0)):
-            raise IndexError('Channel index should be positive and less ' +
-                             'than the number of channels ' +
-                             '({})'.format(self._sizeC + 1))
-        self._channel = channel
+    def __init__(self, filename, meta=True, java_memory='512m',
+                 read_mode='auto', series=0):
+        global loci
 
-    @property
-    def channel_RGB(self):
-        if len(self.channel_RGB_all) == self._sizeC:
-            return [self.channel_RGB_all[c] for c in self.channel]
+        if read_mode not in ['auto', 'jpype', 'stringbuffer', 'javacasting']:
+            raise ValueError('Invalid read_mode value.')
+
+        # Make sure that file exists before starting java
+        if not os.path.isfile(filename):
+            raise IOError('The file "{}" does not exist.'.format(filename))
+
+        # Start java VM and initialize logger (globally)
+        if not jpype.isJVMStarted():
+            loci_path = _find_jar()
+            jpype.startJVM(jpype.getDefaultJVMPath(), '-ea',
+                           '-Djava.class.path=' + loci_path,
+                           '-Xmx' + java_memory)
+            log4j = jpype.JPackage('org.apache.log4j')
+            log4j.BasicConfigurator.configure()
+            log4j_logger = log4j.Logger.getRootLogger()
+            log4j_logger.setLevel(log4j.Level.ERROR)
+
+        if not jpype.isThreadAttachedToJVM():
+            jpype.attachThreadToJVM()
+
+        loci = jpype.JPackage('loci')
+
+        # Initialize reader and metadata
+        self.filename = str(filename)
+        self.rdr = loci.formats.ChannelSeparator(loci.formats.ChannelFiller())
+        if meta:
+            self._metadata = loci.formats.MetadataTools.createOMEXMLMetadata()
+            self.rdr.setMetadataStore(self._metadata)
+        self.rdr.setId(self.filename)
+        if meta:
+            self.metadata = MetadataRetrieve(self._metadata)
+
+        # Checkout reader dtype and define read mode
+        isLittleEndian = self.rdr.isLittleEndian()
+        LE_prefix = ['>', '<'][isLittleEndian]
+        FormatTools = loci.formats.FormatTools
+        self._dtype_dict = {FormatTools.INT8: 'i1',
+                            FormatTools.UINT8: 'u1',
+                            FormatTools.INT16: LE_prefix + 'i2',
+                            FormatTools.UINT16: LE_prefix + 'u2',
+                            FormatTools.INT32: LE_prefix + 'i4',
+                            FormatTools.UINT32: LE_prefix + 'u4',
+                            FormatTools.FLOAT: LE_prefix + 'f4',
+                            FormatTools.DOUBLE: LE_prefix + 'f8'}
+        self._dtype_dict_java = {}
+        for loci_format in self._dtype_dict.keys():
+            self._dtype_dict_java[loci_format] = \
+                (FormatTools.getBytesPerPixel(loci_format),
+                 FormatTools.isFloatingPoint(loci_format),
+                 isLittleEndian)
+
+        # Set the correct series and initialize the sizes
+        self.size_series = self.rdr.getSeriesCount()
+        if series >= self.size_series or series < 0:
+            self.rdr.close()
+            raise IndexError('Series index out of bounds.')
+        self._series = series
+        self._change_series()
+
+        # Set read mode. When auto, tryout fast and check the image size.
+        if read_mode == 'auto':
+            Jarr = self.rdr.openBytes(0)
+            if isinstance(Jarr[:], np.ndarray):
+                read_mode = 'jpype'
+            else:
+                warn('JPype numpy conversion is not installed properly. '
+                     'Falling back to slower read modes.')
+                try:
+                    im = self._jbytearr_stringbuffer(Jarr)
+                    im.reshape(self._sizeRGB, self._sizeX, self._sizeY)
+                except (AttributeError, ValueError):
+                    read_mode = 'javacasting'
+                else:
+                    read_mode = 'stringbuffer'
+        self.read_mode = read_mode
+
+        # Define the names of the standard per frame metadata.
+        self.frame_metadata = {}
+        if meta:
+            if hasattr(self.metadata, 'PlaneDeltaT'):
+                self.frame_metadata['t_s'] = 'PlaneDeltaT'
+            if hasattr(self.metadata, 'PlanePositionX'):
+                self.frame_metadata['x_um'] = 'PlanePositionX'
+            if hasattr(self.metadata, 'PlanePositionY'):
+                self.frame_metadata['y_um'] = 'PlanePositionY'
+            if hasattr(self.metadata, 'PlanePositionZ'):
+                self.frame_metadata['z_um'] = 'PlanePositionZ'
 
     def _change_series(self):
-        super(BioformatsReader, self)._change_series()
-
+        """Changes series and rereads axes, sizes and metadata.
+        """
+        series = self._series
+        self._clear_axes()
+        self.rdr.setSeries(series)
+        sizeX = self.rdr.getSizeX()
+        sizeY = self.rdr.getSizeY()
+        sizeT = self.rdr.getSizeT()
+        sizeZ = self.rdr.getSizeZ()
+        self.isRGB = self.rdr.isRGB()
+        self.isInterleaved = self.rdr.isInterleaved()
         if self.isRGB:
-            self._channel = (0,)
-            self.channel_RGB = []
-        elif self._channel is None:
-            self.channel = tuple(range(self._sizeC))
+            sizeC = self.rdr.getRGBChannelCount()
+            if self.isInterleaved:
+                self._frame_shape_2D = (sizeY, sizeX, sizeC)
+            else:
+                self._frame_shape_2D = (sizeC, sizeY, sizeX)
         else:
-            try:
-                self.channel = self._channel
-            except IndexError:
-                warn("Channel index out of range. Resetting to all channels.",
-                     UserWarning)
-                self.channel = tuple(range(self._sizeC))
+            sizeC = self.rdr.getSizeC()
+            self._frame_shape_2D = (sizeY, sizeX)
 
-    def get_frame(self, t):
-        """Returns image in current series at specified T index. The image is
-        wrapped in a Frame object with specified frame_no and metadata."""
-        shape = (len(self._channel), self._sizeZ, self._sizeY, self._sizeX)
+        self._init_axis('x', sizeX)
+        self._init_axis('y', sizeY)
+        if sizeC > 1:
+            self._init_axis('c', sizeC)
+        if sizeT > 1:
+            self._init_axis('t', sizeT)
+        if sizeZ > 1:
+            self._init_axis('z', sizeZ)
+
+        # determine pixel type
+        pixel_type = self.rdr.getPixelType()
+        dtype = self._dtype_dict[pixel_type]
+        java_dtype = self._dtype_dict_java[pixel_type]
+
+        self._jbytearr_stringbuffer = \
+            lambda arr: _jbytearr_stringbuffer(arr, dtype)
+        self._jbytearr_javacasting = \
+            lambda arr: _jbytearr_javacasting(arr, dtype, *java_dtype)
+        self._pixel_type = dtype
+
+        if 'z' in self.axes:
+            self.bundle_axes = 'zyx'
+        if 't' in self.axes:
+            self.iter_axes = 't'
+
+        # get some metadata fields
+        try:
+            self.colors = [_jrgba_to_rgb(self.metadata.ChannelColor(series, c))
+                           for c in range(sizeC)]
+        except AttributeError:
+            self.colors = None
+        try:
+            self.calibration = self.metadata.PixelsPhysicalSizeX(series)
+        except AttributeError:
+            try:
+                self.calibration = self.metadata.PixelsPhysicalSizeY(series)
+            except:
+                self.calibration = None
+        try:
+            self.calibrationZ = self.metadata.PixelsPhysicalSizeZ(series)
+        except AttributeError:
+            self.calibrationZ = None
+
+    def close(self):
+        self.rdr.close()
+
+    @property
+    def series(self):
+        return self._series
+
+    @series.setter
+    def series(self, value):
+        if value >= self.size_series or value < 0:
+            raise IndexError('Series index out of bounds.')
+        else:
+            if value != self._series:
+                self._series = value
+                self._change_series()
+
+    def get_frame_2D(self, **coords):
+        """Actual reader, returns image as 2D numpy array and metadata as
+        dict.
+        """
+        _coords = {'t': 0, 'c': 0, 'z': 0}
+        _coords.update(coords)
         if self.isRGB:
-            shape = shape + (self._sizeRGB,)
-        imlist = np.zeros(shape, dtype=self.pixel_type)
+            _coords['c'] = 0
+        j = self.rdr.getIndex(_coords['z'], _coords['c'], _coords['t'])
+        if self.read_mode == 'jpype':
+            im = np.frombuffer(self.rdr.openBytes(j)[:],
+                               dtype=self._source_dtype)
+        elif self.read_mode == 'stringbuffer':
+            im = self._jbytearr_stringbuffer(self.rdr.openBytes(j))
+        elif self.read_mode == 'javacasting':
+            im = self._jbytearr_javacasting(self.rdr.openBytes(j))
 
-        mdlist = []
-        for (Nc, c) in enumerate(self._channel):
-            for z in range(self._sizeZ):
-                index = self.get_index(z, c, t)
-                imlist[Nc, z], md = self._get_frame(self.series, index)
-                mdlist.append(md)
-
-        keys = mdlist[0].keys()
-        metadata = {}
-        for k in keys:
-            metadata[k] = [row[k] for row in mdlist]
-            if metadata[k][1:] == metadata[k][:-1]:
-                metadata[k] = metadata[k][0]
-
-        if self.channel_RGB is not None:
-            metadata['colors'] = self.channel_RGB
-
-        return Frame(self.process_func(imlist.squeeze()), frame_no=t,
-                     metadata=metadata)
-
-    class BioformatsND(FramesSequenceND):
-        def __init__(self, filename, meta=True, java_memory='512m',
-                     read_mode='auto', series=0):
-            global loci
-        
-            if read_mode not in ['auto', 'jpype', 'stringbuffer', 'javacasting']:
-                raise ValueError('Invalid read_mode value.')
-        
-            # Make sure that file exists before starting java
-            if not os.path.isfile(filename):
-                raise IOError('The file "{}" does not exist.'.format(filename))
-        
-            # Start java VM and initialize logger (globally)
-            if not jpype.isJVMStarted():
-                loci_path = _find_jar()
-                jpype.startJVM(jpype.getDefaultJVMPath(), '-ea',
-                               '-Djava.class.path=' + loci_path,
-                               '-Xmx' + java_memory)
-                log4j = jpype.JPackage('org.apache.log4j')
-                log4j.BasicConfigurator.configure()
-                log4j_logger = log4j.Logger.getRootLogger()
-                log4j_logger.setLevel(log4j.Level.ERROR)
-        
-            if not jpype.isThreadAttachedToJVM():
-                jpype.attachThreadToJVM()
-        
-            loci = jpype.JPackage('loci')
-        
-            # Initialize reader and metadata
-            self.filename = str(filename)
-            self.rdr = loci.formats.ChannelSeparator(loci.formats.ChannelFiller())
-            if meta:
-                self._metadata = loci.formats.MetadataTools.createOMEXMLMetadata()
-                self.rdr.setMetadataStore(self._metadata)
-            self.rdr.setId(self.filename)
-            if meta:
-                self.metadata = MetadataRetrieve(self._metadata)
-        
-            # Checkout reader dtype and define read mode
-            isLittleEndian = self.rdr.isLittleEndian()
-            LE_prefix = ['>', '<'][isLittleEndian]
-            FormatTools = loci.formats.FormatTools
-            self._dtype_dict = {FormatTools.INT8: 'i1',
-                                FormatTools.UINT8: 'u1',
-                                FormatTools.INT16: LE_prefix + 'i2',
-                                FormatTools.UINT16: LE_prefix + 'u2',
-                                FormatTools.INT32: LE_prefix + 'i4',
-                                FormatTools.UINT32: LE_prefix + 'u4',
-                                FormatTools.FLOAT: LE_prefix + 'f4',
-                                FormatTools.DOUBLE: LE_prefix + 'f8'}
-            self._dtype_dict_java = {}
-            for loci_format in self._dtype_dict.keys():
-                self._dtype_dict_java[loci_format] = \
-                    (FormatTools.getBytesPerPixel(loci_format),
-                     FormatTools.isFloatingPoint(loci_format),
-                     isLittleEndian)
-        
-            # Set the correct series and initialize the sizes
-            self._size_series = self.rdr.getSeriesCount()
-            if series >= self._size_series or series < 0:
-                self.rdr.close()
-                raise IndexError('Series index out of bounds.')
-            self._series = series
-            self._change_series()
-        
-            # Set read mode. When auto, tryout fast and check the image size.
-            if read_mode == 'auto':
-                Jarr = self.rdr.openBytes(0)
-                if isinstance(Jarr[:], np.ndarray):
-                    read_mode = 'jpype'
-                else:
-                    warn('JPype numpy conversion is not installed properly. '
-                         'Falling back to slower read modes.')
-                    try:
-                        im = self._jbytearr_stringbuffer(Jarr)
-                        im.reshape(self._sizeRGB, self._sizeX, self._sizeY)
-                    except (AttributeError, ValueError):
-                        read_mode = 'javacasting'
-                    else:
-                        read_mode = 'stringbuffer'
-            self.read_mode = read_mode
-        
-            # Define the names of the standard per frame metadata.
-            self.frame_metadata = {}
-            if meta:
-                if hasattr(self.metadata, 'PlaneDeltaT'):
-                    self.frame_metadata['t_ms'] = 'PlaneDeltaT'
-                if hasattr(self.metadata, 'PlanePositionX'):
-                    self.frame_metadata['x_um'] = 'PlanePositionX'
-                if hasattr(self.metadata, 'PlanePositionY'):
-                    self.frame_metadata['y_um'] = 'PlanePositionY'
-                if hasattr(self.metadata, 'PlanePositionZ'):
-                    self.frame_metadata['z_um'] = 'PlanePositionZ'
-        
-        def _change_series(self):
-            """Changes series and rereads dtype, sizes and pixelsizes.
-            When pixelsize Y is not found, pixels are assumed to be square.
-            """
-            series = self._series
-            self._clear_axes()
-            self.rdr.setSeries(series)  
-            sizeX = self.rdr.getSizeX()
-            sizeY = self.rdr.getSizeY()
-            sizeT = self.rdr.getSizeT()        
-            sizeZ = self.rdr.getSizeZ()
-            self.isRGB = self.rdr.isRGB()
-            self.isInterleaved = self.rdr.isInterleaved()
-            if self.isRGB:
-                sizeC = self.rdr.getRGBChannelCount()  
-                if self.isInterleaved:
-                    self._frame_shape_2D = (sizeY, sizeX, sizeC)
-                else:
-                    self._frame_shape_2D = (sizeC, sizeY, sizeX)
+        im.shape = self._frame_shape_2D
+        if self.isRGB:
+            if self.isInterleaved:
+                im = im[:, :, coords['c']]
             else:
-                sizeC = self.rdr.getSizeC()
-                self._frame_shape_2D = (sizeY, sizeX)
-        
-            self._init_axis('x', sizeX)
-            self._init_axis('y', sizeY)
-            if sizeC > 1:
-                self._init_axis('c', sizeC)
-            if sizeT > 1:
-                self._init_axis('t', sizeT)
-            if sizeZ > 1:
-                self._init_axis('z', sizeZ)
-        
-            # determine pixel type
-            pixel_type = self.rdr.getPixelType()
-            dtype = self._dtype_dict[pixel_type]
-            java_dtype = self._dtype_dict_java[pixel_type]
-        
-            self._jbytearr_stringbuffer = \
-                lambda arr: _jbytearr_stringbuffer(arr, dtype)
-            self._jbytearr_javacasting = \
-                lambda arr: _jbytearr_javacasting(arr, dtype, *java_dtype)
-            self._pixel_type = dtype
-            
-            if 'z' in self.axes:
-                self.bundle_axes = 'zyx'
-            if 't' in self.axes:
-                self.iter_axes = 't'
-        
-            # get some metadata fields
-            try:
-                self.colors = [_jrgba_to_rgb(self.metadata.ChannelColor(series, c))
-                               for c in range(sizeC)]
-            except AttributeError:
-                self.colors = None
-            try:
-                self.calibration = self.metadata.PixelsPhysicalSizeX(series)
-            except AttributeError:
-                try:
-                    self.calibration = self.metadata.PixelsPhysicalSizeY(series)
-                except:
-                    self.calibration = None
-            try:
-                self.calibrationZ = self.metadata.PixelsPhysicalSizeZ(series)
-            except AttributeError:
-                self.calibrationZ = None
-                
-        def close(self):
-            self.rdr.close()
-            
-        @property
-        def series(self):
-            return self._series
-        @series.setter
-        def series(self, value):
-            if value >= self._size_series or value < 0:
-                raise IndexError('Series index out of bounds.')
-            else:
-                if value != self._series:
-                    self._series = value
-                    self._change_series()
-        
-        def get_frame_2D(self, **coords):
-            """Actual reader, returns image as 2D numpy array and metadata as
-            dict.
-            """
-            _coords = {'t': 0, 'c': 0, 'z': 0}
-            _coords.update(coords)
-            if self.isRGB:
-                _coords['c'] = 0
-            j = self.rdr.getIndex(_coords['z'], _coords['c'], _coords['t'])
-            if self.read_mode == 'jpype':
-                im = np.frombuffer(self.rdr.openBytes(j)[:],
-                                   dtype=self._source_dtype)
-            elif self.read_mode == 'stringbuffer':
-                im = self._jbytearr_stringbuffer(self.rdr.openBytes(j))
-            elif self.read_mode == 'javacasting':
-                im = self._jbytearr_javacasting(self.rdr.openBytes(j))
-        
-            im.shape = self._frame_shape_2D
-            if self.isRGB:
-                if self.isInterleaved:
-                    im = im[:, :, coords['c']]
-                else:
-                    im = im[coords['c'], :, :]
-            im = im.astype(self._pixel_type, copy=False)
-        
-            metadata = {'frame': j,
-                        'series': self._series}
-            if self.colors is not None:
-                metadata['colors'] = self.colors
-            if self.calibration is not None:
-                metadata['mpp'] = self.calibration
-            if self.calibrationZ is not None:
-                metadata['mppZ'] = self.calibrationZ
-            metadata.update(coords)
-            for key, method in self.frame_metadata.items():
-                metadata[key] = getattr(self.metadata, method)(self._series, j)
-        
-            return Frame(im, metadata=metadata)
-        @property
-        def pixel_type(self):
-            return self._pixel_type
+                im = im[coords['c'], :, :]
+        im = im.astype(self._pixel_type, copy=False)
+
+        metadata = {'frame': j,
+                    'series': self._series}
+        if self.colors is not None:
+            metadata['colors'] = self.colors
+        if self.calibration is not None:
+            metadata['mpp'] = self.calibration
+        if self.calibrationZ is not None:
+            metadata['mppZ'] = self.calibrationZ
+        metadata.update(coords)
+        for key, method in self.frame_metadata.items():
+            metadata[key] = getattr(self.metadata, method)(self._series, j)
+
+        return Frame(im, metadata=metadata)
+
+    def get_metadata_raw(self, form='dict'):
+        hashtable = self.rdr.getGlobalMetadata()
+        keys = hashtable.keys()
+        if form == 'dict':
+            result = {}
+            while keys.hasMoreElements():
+                key = keys.nextElement()
+                result[key] = _maybe_tostring(hashtable.get(key))
+        elif form == 'list':
+            result = []
+            while keys.hasMoreElements():
+                key = keys.nextElement()
+                result.append(key + ': ' + _maybe_tostring(hashtable.get(key)))
+        elif form == 'string':
+            result = u''
+            while keys.hasMoreElements():
+                key = keys.nextElement()
+                result += key + ': ' + _maybe_tostring(hashtable.get(key)) + '\n'
+        return result
+
+    @property
+    def reader_class_name(self):
+        return self.rdr.getFormat()

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -68,7 +68,7 @@ def _find_jar(url=None):
 
     from six.moves.urllib.request import urlretrieve
     if url is None:
-        url = ('http://downloads.openmicroscopy.org/bio-formats/5.1.0/' +
+        url = ('http://downloads.openmicroscopy.org/bio-formats/5.1.2/' +
                'artifacts/loci_tools.jar')
     urlretrieve(url, os.path.join(loc, 'loci_tools.jar'))
 

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -496,7 +496,7 @@ class BioformatsReader(FramesSequenceND):
         j = self.rdr.getIndex(_coords['z'], _coords['c'], _coords['t'])
         if self.read_mode == 'jpype':
             im = np.frombuffer(self.rdr.openBytes(j)[:],
-                               dtype=self._source_dtype)
+                               dtype=self._pixel_type)
         elif self.read_mode == 'stringbuffer':
             im = self._jbytearr_stringbuffer(self.rdr.openBytes(j))
         elif self.read_mode == 'javacasting':

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -281,10 +281,13 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
         self.dim_identifiers = dim_identifiers
         super(ImageSequenceND, self).__init__(path_spec, process_func,
                                               dtype, as_grey, plugin)
+                                              
+        self._dim_add('y', self._first_frame_shape[0])
+        self._dim_add('x', self._first_frame_shape[1])
         if 't' in self.dims:
             self.iterate = 't'  # iterate over t
         if 'z' in self.dims:
-            self.aggregate = 'z'  # return z-stacks
+            self.aggregate = 'zyx'  # return z-stacks
 
     def _get_files(self, path_spec):
         super(ImageSequenceND, self)._get_files(path_spec)
@@ -310,22 +313,16 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
             res = res.astype(self._dtype)
         return res
 
-    @property
-    def frame_shape_2D(self):
-        return self._first_frame_shape
-
     def __repr__(self):
         try:
             source = self.pathname
         except AttributeError:
             source = '(list of images)'
-        s = ("<Frames>\nSource: {pathname}\nFrame Shape: {w} x {h}\n " +
-             "Pixel Datatype: {dtype}").format(h=self.frame_shape_2D[0],
-                                               w=self.frame_shape_2D[1],
-                                               pathname=source,
-                                               dtype=self.pixel_type)
+        s = "<ImageSequenceND>\nSource: {0}\n".format(source)
+        s += "Dimensions: {0}\n".format(self.ndim)
         for dim in self._sizes:
-            s += '\nSize {0}: {1}'.format(dim, self._sizes[dim])
+            s += "Dimension '{0}' size: {1}\n".format(dim, self._sizes[dim])
+        s += """Pixel Datatype: {dtype}""".format(dtype=self.pixel_type)
         return s
 
 

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -13,7 +13,7 @@ from six.moves import StringIO
 
 import numpy as np
 
-from pims.base_frames import FramesSequence, Multidimensional
+from pims.base_frames import FramesSequence, FramesSequenceND
 from pims.frame import Frame
 from pims.utils.sort import natural_keys
 
@@ -225,7 +225,7 @@ def filename_to_indices(filename, identifiers='tzc'):
     return result
 
 
-class ImageSequenceND(Multidimensional, ImageSequence):
+class ImageSequenceND(FramesSequenceND, ImageSequence):
     """Read a directory of multi-indexed image files into an iterable that
     returns images as numpy arrays. By default, the extra dimensions are
     denoted with t, z, c.
@@ -295,7 +295,7 @@ class ImageSequenceND(Multidimensional, ImageSequence):
                 self._toc = np.delete(self._toc, n, axis=1)
             else:
                 self._toc[:, n] = self._toc[:, n] - min(self._toc[:, n])
-                self.add_dim(name, max(self._toc[:, n]) + 1)
+                self._dim_add(name, max(self._toc[:, n]) + 1)
         self._filepaths = np.array(self._filepaths)
 
     def get_frame(self, i):
@@ -324,8 +324,8 @@ class ImageSequenceND(Multidimensional, ImageSequence):
                                                w=self.frame_shape_2D[1],
                                                pathname=source,
                                                dtype=self.pixel_type)
-        for dim in self.dims:
-            s += '\nSize {0}: {1}'.format(dim, self.dims[dim].size)
+        for dim in self._sizes:
+            s += '\nSize {0}: {1}'.format(dim, self._sizes[dim])
         return s
 
 

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -257,24 +257,23 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
     Attributes
     ----------
     axes : list of strings
-        List of all available dimensions
+        List of all available axes
     ndim : int
-        Number of image dimensions
+        Number of image axes
     sizes : dict of int
-        Dictionary with all dimension sizes
+        Dictionary with all axis sizes
     frame_shape : tuple of int
         Shape of frames that will be returned by get_frame
     iter_axes : iterable of strings
-        This determines which dimensions will be iterated over by the
-        FramesSequence. The last element in will iterate fastest.
-        x and y are not allowed. Defaults to ['t'].
+        This determines which axes will be iterated over by the FramesSequence.
+        The last element in will iterate fastest. x and y are not allowed.
     bundle_axes : iterable of strings
-        This determines which dimensions will be aggregated into one Frame.
-        The dimensions in the ndarray that is returned by get_frame has
-        the same order as the order in this list. The last two elements have
-        to be ['y', 'x']. Defaults to ['z', 'y', 'x'].
+        This determines which axes will be bundled into one Frame. The axes in
+        the ndarray that is returned by get_frame have the same order as the
+        order in this list. The last two elements have to be ['y', 'x'].
+        Defaults to ['z', 'y', 'x'].
     default_coords: dict of int
-        When a dimension is not present in both iterate and aggregate, the
+        When a dimension is not present in both iter_axes and bundle_axes, the
         coordinate contained in this dictionary will be used.
     """
     def __init__(self, path_spec, process_func=None, dtype=None,

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -13,7 +13,7 @@ from six.moves import StringIO
 
 import numpy as np
 
-from pims.base_frames import FramesSequence
+from pims.base_frames import FramesSequence, Multidimensional
 from pims.frame import Frame
 from pims.utils.sort import natural_keys
 
@@ -193,33 +193,30 @@ Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
                                   dtype=self.pixel_type)
 
 
-def filename_to_tzc(filename, identifiers=None):
-    """ Find ocurrences of z/t/c + number (e.g. t001, z06, c2)
-    in a filename and returns a list of [t, z, c] coordinates
+def filename_to_indices(filename, identifiers='tzc'):
+    """ Find ocurrences of dimension indices (e.g. t001, z06, c2)
+    in a filename and returns a list of indices.
 
     Parameters
     ----------
     filename : string
-        filename to be searched for t, z, c indices
-    identifiers : list of string, optional
-        3 strings preceding t, z, c indices, in that order
+        filename to be searched for indices
+    identifiers : string or list of strings, optional
+        iterable of N strings preceding dimension indices, in that order
 
     Returns
     ---------
     list of int
-        t, z, c indices. Elements default to 0 when index was not found.
+        dimension indices. Elements default to 0 when index was not found.
 
     """
-    if identifiers is None:
-        identifiers = tzc = ['t', 'z', 'c']
-    else:
-        tzc = [re.escape(a) for a in identifiers]
-    dimensions = re.findall(r'({0}|{1}|{2})(\d+)'.format(*tzc),
+    escaped = [re.escape(a) for a in identifiers]
+    dimensions = re.findall('(' + '|'.join(escaped) + r')(\d+)',
                             filename)
-    if len(dimensions) > 3:
+    if len(dimensions) > len(identifiers):
         dimensions = dimensions[-3:]
     order = [a[0] for a in dimensions]
-    result = [0, 0, 0]
+    result = [0] * len(identifiers)
     for (i, col) in enumerate(identifiers):
         try:
             result[i] = int(dimensions[order.index(col)][1])
@@ -228,9 +225,10 @@ def filename_to_tzc(filename, identifiers=None):
     return result
 
 
-class ImageSequence3D(ImageSequence):
-    """Read a directory of (t, z, c) numbered image files into an
-    iterable that returns images as numpy arrays, indexed by t.
+class ImageSequenceND(Multidimensional, ImageSequence):
+    """Read a directory of multi-indexed image files into an iterable that
+    returns images as numpy arrays. By default, the extra dimensions are
+    denoted with t, z, c.
 
     Parameters
     ----------
@@ -248,90 +246,87 @@ class ImageSequence3D(ImageSequence):
         Image arrays will be converted to this datatype.
     as_grey : boolean, optional
         Not implemented for 3D images.
-    plugin : string
+    plugin : string, optional
         Passed on to skimage.io.imread if scikit-image is available.
         If scikit-image is not available, this will be ignored and a warning
         will be issued. Not available in combination with zipfiles.
-    tzc_identifiers : list of string, optional
-        3 strings preceding t, z, c indices. Default ['t', 'z', 'c'].
+    dim_identifiers : iterable of strings, optional
+        N strings preceding dimension indices. Default 'tzc'. x and y are not
+        allowed.
 
+    Attributes
+    ----------
+    dims : dict of FramesDimension objects
+        Dictionary of all available dimensions (excluding x and y)
+    ndim : int
+        Number of dimensions including x and y
+    sizes : dict of int
+        Dictionary with all dimension sizes
+    frame_shape : tuple of int
+        Shape of frames that will be returned by get_frame
+    frame_shape_2D : tuple of int
+        Size (y, x)
+    iterate : iterable of strings
+        This determines which dimensions will be iterated over by the
+        FramesSequence. The last element in will iterate fastest.
+    aggregate : iterable of strings
+        This determines which dimensions will be aggregated into one.
+        Frame. The dimensions in the ndarray that is returned by get_frame has
+        the same order as the order in this list.
     """
     def __init__(self, path_spec, process_func=None, dtype=None,
-                 as_grey=False, plugin=None, tzc_identifiers=None):
-        self.tzc_identifiers = tzc_identifiers
-        super(ImageSequence3D, self).__init__(path_spec, process_func,
+                 as_grey=False, plugin=None, dim_identifiers='tzc'):
+        if as_grey:
+            raise ValueError('As grey not supported for ND images')
+        self.dim_identifiers = dim_identifiers
+        super(ImageSequenceND, self).__init__(path_spec, process_func,
                                               dtype, as_grey, plugin)
+        if 't' in self.dims:
+            self.iterate = 't'  # iterate over t
+        if 'z' in self.dims:
+            self.aggregate = 'z'  # return z-stacks
 
     def _get_files(self, path_spec):
-        super(ImageSequence3D, self)._get_files(path_spec)
-        self._toc = np.array([filename_to_tzc(f, self.tzc_identifiers) \
+        super(ImageSequenceND, self)._get_files(path_spec)
+        self._toc = np.array([filename_to_indices(f, self.dim_identifiers) \
                               for f in self._filepaths])
-        for n in range(3):
-            self._toc[:, n] = self._toc[:, n] - min(self._toc[:, n])
+        for n, name in enumerate(self.dim_identifiers):
+            if np.all(self._toc[:, n] == 0):
+                self._toc = np.delete(self._toc, n, axis=1)
+            else:
+                self._toc[:, n] = self._toc[:, n] - min(self._toc[:, n])
+                self.add_dim(name, max(self._toc[:, n]) + 1)
         self._filepaths = np.array(self._filepaths)
-        self._count = max(self._toc[:, 0]) + 1
-        self._sizeZ = max(self._toc[:, 1]) + 1
-        self._sizeC = max(self._toc[:, 2]) + 1
-        self._channel = list(range(self._sizeC))
 
-    def get_frame(self, j):
-        if j > self._count:
-            raise ValueError("File does not contain this many frames")
-        res = np.zeros((len(self._channel), self._sizeZ,
-                        self._first_frame_shape[0],
-                        self._first_frame_shape[1]),
-                       dtype=self._dtype)
-        for (Nc, c) in enumerate(self._channel):
-            selector = np.logical_and(self._toc[:, 0] == j,
-                                      self._toc[:, 2] == c)
-            filelist = self._filepaths[selector]
-            for (z, loc) in enumerate(filelist):
-                res[Nc, z] = self.imread(loc, **self.kwargs)
+    def get_frame(self, i):
+        frame = super(ImageSequenceND, self).get_frame(i)
+        return Frame(self.process_func(frame), frame_no=i)
 
-        return Frame(self.process_func(res.squeeze()), frame_no=j)
+    def get_frame_2D(self, **ind):
+        row = [ind[name] for name in self.dim_identifiers]
+        i = np.argwhere(np.all(self._toc == row, 1))[0, 0]
+        res = self.imread(self._filepaths[i], **self.kwargs)
+        if res.dtype != self._dtype:
+            res = res.astype(self._dtype)
+        return res
 
     @property
-    def sizes(self):
-        return {'X': self._first_frame_shape[1],
-                'Y': self._first_frame_shape[0],
-                'Z': self._sizeZ,
-                'T': self._count,
-                'C': self._sizeC}
-
-    @property
-    def channel(self):
-        return self._channel
-
-    @channel.setter
-    def channel(self, value):
-        try:
-            channel = tuple(value)
-        except TypeError:
-            channel = tuple((value,))
-        if np.any(np.greater_equal(channel, self._sizeC)) or \
-           np.any(np.less(channel, 0)):
-            raise IndexError('Channel index out of bounds.')
-        self._channel = channel
+    def frame_shape_2D(self):
+        return self._first_frame_shape
 
     def __repr__(self):
-        # May be overwritten by subclasses
         try:
             source = self.pathname
         except AttributeError:
             source = '(list of images)'
-        return """<Frames>
-Source: {pathname}
-SizeT: {count} frames
-SizeZ: {Z} frames
-SizeC: {C} frames
-Frame Shape: {w} x {h}
-Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
-                                  h=self.frame_shape[1],
-                                  count=len(self),
-                                  pathname=source,
-                                  dtype=self.pixel_type,
-                                  C=self._sizeC,
-                                  Z=self._sizeZ)
+        s = ("<Frames>\nSource: {pathname}\nFrame Shape: {w} x {h}\n " +
+             "Pixel Datatype: {dtype}").format(h=self.frame_shape_2D[0],
+                                               w=self.frame_shape_2D[1],
+                                               pathname=source,
+                                               dtype=self.pixel_type)
+        for dim in self.dims:
+            s += '\nSize {0}: {1}'.format(dim, self.dims[dim].size)
+        return s
 
 
 def customize_image_sequence(imread_func, name=None):

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -256,23 +256,26 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
 
     Attributes
     ----------
-    dims : dict of FramesDimension objects
-        Dictionary of all available dimensions (excluding x and y)
+    dims : list of strings
+        List of all available dimensions
     ndim : int
-        Number of dimensions including x and y
+        Number of image dimensions
     sizes : dict of int
         Dictionary with all dimension sizes
     frame_shape : tuple of int
         Shape of frames that will be returned by get_frame
-    frame_shape_2D : tuple of int
-        Size (y, x)
     iterate : iterable of strings
         This determines which dimensions will be iterated over by the
         FramesSequence. The last element in will iterate fastest.
+        x and y are not allowed. Defaults to ['t'].
     aggregate : iterable of strings
-        This determines which dimensions will be aggregated into one.
-        Frame. The dimensions in the ndarray that is returned by get_frame has
-        the same order as the order in this list.
+        This determines which dimensions will be aggregated into one Frame.
+        The dimensions in the ndarray that is returned by get_frame has
+        the same order as the order in this list. The last two elements have
+        to be ['y', 'x']. Defaults to ['z', 'y', 'x'].
+    default_coords: dict of int
+        When a dimension is not present in both iterate and aggregate, the
+        coordinate contained in this dictionary will be used.
     """
     def __init__(self, path_spec, process_func=None, dtype=None,
                  as_grey=False, plugin=None, dim_identifiers='tzc'):

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -250,16 +250,14 @@ class TestRecursiveSlicing(unittest.TestCase):
 
 class TestMultidimensional(unittest.TestCase):
     def setUp(self):
-        class IndexReturningReader(pims.base_frames.FramesSequenceND):
+        class IndexReturningReader(pims.FramesSequenceND):
             @property
             def pixel_type(self):
                 pass
 
-            @property
-            def frame_shape_2D(self):
-                return self._frame_shape_2D
-
             def __init__(self, **dims):
+                self._dim_add('x', len(dims))
+                self._dim_add('y', 1)
                 for k in dims:
                     self._dim_add(k, dims[k])
                 self._frame_shape_2D = (1, len(dims))
@@ -301,13 +299,13 @@ class TestMultidimensional(unittest.TestCase):
             assert_equal(self.v[i], [[0, 0, i, 0]])
 
     def test_aggregate(self):
-        self.v.aggregate = 'z'
+        self.v.aggregate = 'zyx'
         assert_equal(self.v[0].shape, (20, 1, 4))
-        self.v.aggregate = 'c'
+        self.v.aggregate = 'cyx'
         assert_equal(self.v[0].shape, (3, 1, 4))
-        self.v.aggregate = 'cz'
+        self.v.aggregate = 'czyx'
         assert_equal(self.v[0].shape, (3, 20, 1, 4))
-        self.v.aggregate = 'zc'
+        self.v.aggregate = 'zcyx'
         assert_equal(self.v[0].shape, (20, 3, 1, 4))
 
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -256,10 +256,10 @@ class TestMultidimensional(unittest.TestCase):
                 pass
 
             def __init__(self, **dims):
-                self._dim_add('x', len(dims))
-                self._dim_add('y', 1)
+                self._init_axis('x', len(dims))
+                self._init_axis('y', 1)
                 for k in dims:
-                    self._dim_add(k, dims[k])
+                    self._init_axis(k, dims[k])
                 self._frame_shape_2D = (1, len(dims))
 
             def get_frame_2D(self, **ind):
@@ -268,21 +268,21 @@ class TestMultidimensional(unittest.TestCase):
         self.v = IndexReturningReader(c=3, m=5, t=100, z=20)
 
     def test_iterate(self):
-        self.v.iterate = 't'
+        self.v.iter_axes = 't'
         for i in [0, 1, 15]:
             assert_equal(self.v[i], [[0, 0, i, 0]])
-        self.v.iterate = 'm'
+        self.v.iter_axes = 'm'
         for i in [0, 1, 3]:
             assert_equal(self.v[i], [[0, i, 0, 0]])
-        self.v.iterate = 'zc'
+        self.v.iter_axes = 'zc'
         assert_equal(self.v[0], [[0, 0, 0, 0]])
         assert_equal(self.v[2], [[2, 0, 0, 0]])
         assert_equal(self.v[30], [[0, 0, 0, 10]])
-        self.v.iterate = 'cz'
+        self.v.iter_axes = 'cz'
         assert_equal(self.v[0], [[0, 0, 0, 0]])
         assert_equal(self.v[4], [[0, 0, 0, 4]])
         assert_equal(self.v[21], [[1, 0, 0, 1]])
-        self.v.iterate = 'tzc'
+        self.v.iter_axes = 'tzc'
         assert_equal(self.v[0], [[0, 0, 0, 0]])
         assert_equal(self.v[4], [[1, 0, 0, 1]])
         assert_equal(self.v[180], [[0, 0, 3, 0]])
@@ -290,7 +290,7 @@ class TestMultidimensional(unittest.TestCase):
         assert_equal(self.v[212], [[2, 0, 3, 10]])
 
     def test_default(self):
-        self.v.iterate = 't'
+        self.v.iter_axes = 't'
         self.v.default_coords['m'] = 2
         for i in [0, 1, 3]:
             assert_equal(self.v[i], [[0, 2, i, 0]])
@@ -298,14 +298,14 @@ class TestMultidimensional(unittest.TestCase):
         for i in [0, 1, 3]:
             assert_equal(self.v[i], [[0, 0, i, 0]])
 
-    def test_aggregate(self):
-        self.v.aggregate = 'zyx'
+    def test_bundle(self):
+        self.v.bundle_axes = 'zyx'
         assert_equal(self.v[0].shape, (20, 1, 4))
-        self.v.aggregate = 'cyx'
+        self.v.bundle_axes = 'cyx'
         assert_equal(self.v[0].shape, (3, 1, 4))
-        self.v.aggregate = 'czyx'
+        self.v.bundle_axes = 'czyx'
         assert_equal(self.v[0].shape, (3, 20, 1, 4))
-        self.v.aggregate = 'zcyx'
+        self.v.bundle_axes = 'zcyx'
         assert_equal(self.v[0].shape, (20, 3, 1, 4))
 
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -250,7 +250,7 @@ class TestRecursiveSlicing(unittest.TestCase):
 
 class TestMultidimensional(unittest.TestCase):
     def setUp(self):
-        class IndexReturningReader(pims.base_frames.Multidimensional):
+        class IndexReturningReader(pims.base_frames.FramesSequenceND):
             @property
             def pixel_type(self):
                 pass
@@ -261,7 +261,7 @@ class TestMultidimensional(unittest.TestCase):
 
             def __init__(self, **dims):
                 for k in dims:
-                    self.add_dim(k, dims[k])
+                    self._dim_add(k, dims[k])
                 self._frame_shape_2D = (1, len(dims))
 
             def get_frame_2D(self, **ind):
@@ -293,10 +293,10 @@ class TestMultidimensional(unittest.TestCase):
 
     def test_default(self):
         self.v.iterate = 't'
-        self.v.m.default = 2
+        self.v.default_coords['m'] = 2
         for i in [0, 1, 3]:
             assert_equal(self.v[i], [[0, 2, i, 0]])
-        self.v.m.default = 0
+        self.v.default_coords['m'] = 0
         for i in [0, 1, 3]:
             assert_equal(self.v[i], [[0, 0, i, 0]])
 
@@ -648,7 +648,7 @@ class ImageSequenceND(_image_series):
         self.klass = pims.ImageSequenceND
         self.kwargs = dict(dim_identifiers='tzc')
         self.v = self.klass(self.filename, **self.kwargs)
-        self.v.c.default = 0
+        self.v.default_coords['c'] = 0
         self.expected_len = 3
         self.expected_Z = 2
         self.expected_C = 2

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -260,8 +260,8 @@ class TestMultidimensional(unittest.TestCase):
                 return self._frame_shape_2D
 
             def __init__(self, **dims):
-                for k, v in dims.iteritems():
-                    self.add_dim(k, v)
+                for k in dims:
+                    self.add_dim(k, dims[k])
                 self._frame_shape_2D = (1, len(dims))
 
             def get_frame_2D(self, **ind):

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -293,9 +293,12 @@ class TestMultidimensional(unittest.TestCase):
 
     def test_default(self):
         self.v.iterate = 't'
-        self.v.dims['m'].default = 2
+        self.v.m.default = 2
         for i in [0, 1, 3]:
             assert_equal(self.v[i], [[0, 2, i, 0]])
+        self.v.m.default = 0
+        for i in [0, 1, 3]:
+            assert_equal(self.v[i], [[0, 0, i, 0]])
 
     def test_aggregate(self):
         self.v.aggregate = 'z'
@@ -618,7 +621,7 @@ class TestOpenFiles(unittest.TestCase):
         pims.open(os.path.join(path, 'stuck.tif'))
 
 
-class ImageSequence3D(_image_series):
+class ImageSequenceND(_image_series):
     def check_skip(self):
         pass
 
@@ -642,50 +645,44 @@ class ImageSequence3D(_image_series):
         self.filename = os.path.join(self.filepath, '*.png')
         self.frame0 = np.array([frames[0], frames[2]])
         self.frame1 = np.array([frames[4], frames[6]])
-        self.klass = pims.ImageSequence3D
-        self.kwargs = dict()
+        self.klass = pims.ImageSequenceND
+        self.kwargs = dict(dim_identifiers='tzc')
         self.v = self.klass(self.filename, **self.kwargs)
-        self.v.channel = 0
-        self.expected_shape = shape
+        self.v.c.default = 0
         self.expected_len = 3
         self.expected_Z = 2
         self.expected_C = 2
+        self.expected_shape = (self.expected_Z,) + shape
 
     def tearDown(self):
         clean_dummy_png(self.filepath, self.filenames)
 
     def test_filename_tzc(self):
-        tzc = pims.image_sequence.filename_to_tzc('file_t01_z005_c4.png')
+        tzc = pims.image_sequence.filename_to_indices('file_t01_z005_c4.png')
         self.assertEqual(tzc, [1, 5, 4])
-        tzc = pims.image_sequence.filename_to_tzc('t01file_t01_z005_c4.png')
+        tzc = pims.image_sequence.filename_to_indices('t01file_t01_z005_c4.png')
         self.assertEqual(tzc, [1, 5, 4])
-        tzc = pims.image_sequence.filename_to_tzc('file_z005_c4_t01.png')
+        tzc = pims.image_sequence.filename_to_indices('file_z005_c4_t01.png')
         self.assertEqual(tzc, [1, 5, 4])
-        tzc = pims.image_sequence.filename_to_tzc(u'file\u03BC_z05_c4_t01.png')
+        tzc = pims.image_sequence.filename_to_indices(u'file\u03BC_z05_c4_t01.png')
         self.assertEqual(tzc, [1, 5, 4])
-        tzc = pims.image_sequence.filename_to_tzc('file_t9415_z005.png')
+        tzc = pims.image_sequence.filename_to_indices('file_t9415_z005.png')
         self.assertEqual(tzc, [9415, 5, 0])
-        tzc = pims.image_sequence.filename_to_tzc('file_t47_c34.png')
+        tzc = pims.image_sequence.filename_to_indices('file_t47_c34.png')
         self.assertEqual(tzc, [47, 0, 34])
-        tzc = pims.image_sequence.filename_to_tzc('file_z4_c2.png')
+        tzc = pims.image_sequence.filename_to_indices('file_z4_c2.png')
         self.assertEqual(tzc, [0, 4, 2])
-        tzc = pims.image_sequence.filename_to_tzc('file_x4_c2_y5_z1.png',
-                                                  ['x', 'y', 'z'])
+        tzc = pims.image_sequence.filename_to_indices('file_x4_c2_y5_z1.png',
+                                                      ['x', 'y', 'z'])
         self.assertEqual(tzc, [4, 5, 1])
 
     def test_sizeZ(self):
         self.check_skip()
-        assert_equal(self.v.sizes['Z'], self.expected_Z)
+        assert_equal(self.v.sizes['z'], self.expected_Z)
 
     def test_sizeC(self):
         self.check_skip()
-        assert_equal(self.v.sizes['C'], self.expected_C)
-
-    def test_change_channels(self):
-        self.check_skip()
-        self.v.channel = (0, 1)
-        assert_equal(self.v[0].shape, (2, 2, self.expected_shape[0],
-                                       self.expected_shape[1]))
+        assert_equal(self.v.sizes['c'], self.expected_C)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This implements a base class that allows flexible reading and iteration through a file with multiple dimensions.  The properties `aggregate` and `iterate` define how each dimension functions, as discussed in #124 and #150 

I based the `ImageSequenceND` reader on this, I'll wait for your response until rebasing the `Bioformats` reader.

The base class itself is quite extensive, so that the derived classed can be slim:

    >>> class MDummy(Multidimensional):
    ...    @property
    ...    def pixel_type(self):
    ...        return 'uint8'
    ...    @property
    ...    def frame_shape_2D(self):
    ...        return self._frame_shape_2D
    ...    def __init__(self, shape, **dims):
    ...        for name in dims:
    ...            self.add_dim(name, dims[name])
    ...        self._frame_shape_2D = shape
    ...    def get_frame_2D(self, **ind):
    ...        return np.zeros(self.frame_shape_2D, dtype=self.pixel_type)

    >>> frames = MDummy((64, 64), t=80, c=2, z=10, m=5)
    >>> frames.aggregate = 'cz'
    >>> frames.iterate = 't'
    >>> frames.m.default = 3
    >>> frames[5]  # returns Frame at T=5, M=3 with shape (2, 10, 64, 64)

