### PR TITLE
ENH: Propagate Frame metadata through pipeline.

### DIFF
--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -515,6 +515,12 @@ def pipeline(func):
             s = SliceableIterable(img_or_iterable, range(_len), _len)
             s._proc_func = lambda image: func(image, *args, **kwargs)
             return s
+        elif isinstance(img_or_iterable, Frame):
+            # Fall back on normal behavior of func, interpreting input
+            # as a single image, but propagate frame_no and metadata.
+            return pims.Frame(func(img_or_iterable),
+                              frame_no=img_or_iterable.frame_no,
+                              metadata=img_or_iterable.metadata)
         else:
             # Fall back on normal behavior of func, interpreting input
             # as a single image.


### PR DESCRIPTION
Need tests.

As a sidenote, I tried the pipeline feature out with trackpy "in production" this weekend while addressing some reviewers' comments. I really like it. The raw video is so badly lit it's hard to see anything at all, so this usage is really nice:

```
@pims.pipeline
def preprocess(image):
    return pims.Frame(tp.bandpass(np.invert(image), 1, 11), frame_no=image.frame_no)
v = preprocess(raw_video)
```

This PR would simplify that to:

```
@pims.pipeline
def preprocess(image):
    return tp.bandpass(np.invert(image), 1, 11)
v = preprocess(raw_video)
```