### PR TITLE
ENH: Make ImageSequenceND work with RGB files

### DIFF
--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -628,7 +628,7 @@ class FramesSequenceND(FramesSequence):
         the ndarray that is returned by get_frame have the same order as the
         order in this list. The last two elements have to be ['y', 'x'].
     default_coords: dict of int
-        When a dimension is not present in both iter_axes and bundle_axes, the
+        When an axis is not present in both iter_axes and bundle_axes, the
         coordinate contained in this dictionary will be used.
 
     Examples
@@ -663,7 +663,7 @@ class FramesSequenceND(FramesSequence):
         if not hasattr(self, '_sizes'):
             self._clear_axes()
         elif name in self._sizes:
-            raise ValueError("dimension '{}' already exists".format(name))
+            raise ValueError("axis '{}' already exists".format(name))
         self._sizes[name] = int(size)
         if not (name == 'x' or name == 'y'):
             self.default_coords[name] = int(default)
@@ -693,8 +693,8 @@ class FramesSequenceND(FramesSequence):
 
     @property
     def bundle_axes(self):
-        """ This determines which dimensions will be bundled into one Frame.
-        The ndarray that is returned by get_frame has the same dimension order
+        """ This determines which axes will be bundled into one Frame.
+        The ndarray that is returned by get_frame has the same axis order
         as the order of `bundle_axes`.
         The last two elements have to be ['y', 'x'].
         """
@@ -774,7 +774,7 @@ class FramesSequenceND(FramesSequence):
         # start with the default coordinates
         coords = self._default_coords.copy()
 
-        # list sizes of iterate dimensions
+        # list sizes of iterate axes
         iter_sizes = [self._sizes[k] for k in self._iter_axes]
         # list how much i has to increase to get an increase of coordinate n
         iter_cumsizes = np.append(np.cumprod(iter_sizes[::-1])[-2::-1], 1)
@@ -831,8 +831,8 @@ class FramesSequenceND(FramesSequence):
         return Frame(result, frame_no=i, metadata=metadata)
 
     def __repr__(self):
-        s = "<FramesSequenceND>\nDimensions: {0}\n".format(self.ndim)
+        s = "<FramesSequenceND>\nAxes: {0}\n".format(self.ndim)
         for dim in self._sizes:
-            s += "Dimension '{0}' size: {1}\n".format(dim, self._sizes[dim])
+            s += "Axis '{0}' size: {1}\n".format(dim, self._sizes[dim])
         s += """Pixel Datatype: {dtype}""".format(dtype=self.pixel_type)
         return s

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -194,7 +194,7 @@ Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
 
 
 def filename_to_indices(filename, identifiers='tzc'):
-    """ Find ocurrences of dimension indices (e.g. t001, z06, c2)
+    """ Find ocurrences of axis indices (e.g. t001, z06, c2)
     in a filename and returns a list of indices.
 
     Parameters
@@ -202,24 +202,24 @@ def filename_to_indices(filename, identifiers='tzc'):
     filename : string
         filename to be searched for indices
     identifiers : string or list of strings, optional
-        iterable of N strings preceding dimension indices, in that order
+        iterable of N strings preceding axis indices, in that order
 
     Returns
     ---------
     list of int
-        dimension indices. Elements default to 0 when index was not found.
+        axis indices. Elements default to 0 when index was not found.
 
     """
     escaped = [re.escape(a) for a in identifiers]
-    dimensions = re.findall('(' + '|'.join(escaped) + r')(\d+)',
+    axes = re.findall('(' + '|'.join(escaped) + r')(\d+)',
                             filename)
-    if len(dimensions) > len(identifiers):
-        dimensions = dimensions[-3:]
-    order = [a[0] for a in dimensions]
+    if len(axes) > len(identifiers):
+        axes = axes[-3:]
+    order = [a[0] for a in axes]
     result = [0] * len(identifiers)
     for (i, col) in enumerate(identifiers):
         try:
-            result[i] = int(dimensions[order.index(col)][1])
+            result[i] = int(axes[order.index(col)][1])
         except ValueError:
             result[i] = 0
     return result
@@ -227,7 +227,7 @@ def filename_to_indices(filename, identifiers='tzc'):
 
 class ImageSequenceND(FramesSequenceND, ImageSequence):
     """Read a directory of multi-indexed image files into an iterable that
-    returns images as numpy arrays. By default, the extra dimensions are
+    returns images as numpy arrays. By default, the extra axes are
     denoted with t, z, c.
 
     Parameters
@@ -237,7 +237,7 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
         which will ignore extraneous files or a list of files to open
         in the order they should be loaded. When a path to a zipfile is
         specified, all files in the zipfile will be loaded. The filenames
-        should contain the indices of T, Z and C, preceded by a dimension
+        should contain the indices of T, Z and C, preceded by a axis
         identifier such as: 'file_t001c05z32'.
     process_func : function, optional
         callable with signature `proc_img = process_func(img)`,
@@ -250,9 +250,9 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
         Passed on to skimage.io.imread if scikit-image is available.
         If scikit-image is not available, this will be ignored and a warning
         will be issued. Not available in combination with zipfiles.
-    dim_identifiers : iterable of strings, optional
-        N strings preceding dimension indices. Default 'tzc'. x and y are not
-        allowed.
+    axes_identifiers : iterable of strings, optional
+        N strings preceding axes indices. Default 'tzc'. x and y are not
+        allowed. c is not allowed when images are RGB.
 
     Attributes
     ----------
@@ -273,18 +273,44 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
         order in this list. The last two elements have to be ['y', 'x'].
         Defaults to ['z', 'y', 'x'].
     default_coords: dict of int
-        When a dimension is not present in both iter_axes and bundle_axes, the
+        When an axis is not present in both iter_axes and bundle_axes, the
         coordinate contained in this dictionary will be used.
     """
     def __init__(self, path_spec, process_func=None, dtype=None,
-                 as_grey=False, plugin=None, dim_identifiers='tzc'):
+                 as_grey=False, plugin=None, axes_identifiers='tzc'):
         if as_grey:
             raise ValueError('As grey not supported for ND images')
-        self.dim_identifiers = dim_identifiers
+        if 'x' in axes_identifiers:
+            raise ValueError("Axis 'x' is reserved")
+        if 'y' in axes_identifiers:
+            raise ValueError("Axis 'y' is reserved")
+        self.axes_identifiers = axes_identifiers
         super(ImageSequenceND, self).__init__(path_spec, process_func,
                                               dtype, as_grey, plugin)
-        self._init_axis('y', self._first_frame_shape[0])
-        self._init_axis('x', self._first_frame_shape[1])
+        shape = self._first_frame_shape
+        if len(shape) == 2:
+            self._init_axis('y', shape[0])
+            self._init_axis('x', shape[1])
+            self.isRGB = False
+        elif len(shape) == 3 and shape[2] in [3, 4]:
+            self._init_axis('y', shape[0])
+            self._init_axis('x', shape[1])
+            self._init_axis('c', shape[2])
+            self.isRGB = True
+            self.isInterleaved = True
+        elif len(shape) == 3 and shape[0] in [3, 4]:
+            self._init_axis('c', shape[0])
+            self._init_axis('y', shape[1])
+            self._init_axis('x', shape[2])
+            self.isRGB = True
+            self.isInterleaved = False
+        else:
+            raise IOError("Could not interpret image shape.")
+
+        if self.isRGB and 'c' in self.axes_identifiers:
+            raise ValueError("Axis identifier 'c' is reserved when "
+                             "images are rgb.")
+
         if 't' in self.axes:
             self.iter_axes = 't'  # iterate over t
         if 'z' in self.axes:
@@ -292,9 +318,9 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
 
     def _get_files(self, path_spec):
         super(ImageSequenceND, self)._get_files(path_spec)
-        self._toc = np.array([filename_to_indices(f, self.dim_identifiers)
+        self._toc = np.array([filename_to_indices(f, self.axes_identifiers)
                               for f in self._filepaths])
-        for n, name in enumerate(self.dim_identifiers):
+        for n, name in enumerate(self.axes_identifiers):
             if np.all(self._toc[:, n] == 0):
                 self._toc = np.delete(self._toc, n, axis=1)
             else:
@@ -307,12 +333,22 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
         return Frame(self.process_func(frame), frame_no=i)
 
     def get_frame_2D(self, **ind):
-        row = [ind[name] for name in self.dim_identifiers]
+        if self.isRGB:
+            c = ind['c']
+            row = [ind[name] for name in self.axes_identifiers if name != 'c']
+        else:
+            row = [ind[name] for name in self.axes_identifiers]
         i = np.argwhere(np.all(self._toc == row, 1))[0, 0]
         res = self.imread(self._filepaths[i], **self.kwargs)
         if res.dtype != self._dtype:
             res = res.astype(self._dtype)
-        return res
+        if self.isRGB:
+            if self.isInterleaved:
+                return res[:, :, c]
+            else:
+                return res[c]
+        else:
+            return res
 
     def __repr__(self):
         try:
@@ -320,9 +356,9 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
         except AttributeError:
             source = '(list of images)'
         s = "<ImageSequenceND>\nSource: {0}\n".format(source)
-        s += "Dimensions: {0}\n".format(self.ndim)
+        s += "Axes: {0}\n".format(self.ndim)
         for dim in self._sizes:
-            s += "Dimension '{0}' size: {1}\n".format(dim, self._sizes[dim])
+            s += "Axis '{0}' size: {1}\n".format(dim, self._sizes[dim])
         s += """Pixel Datatype: {dtype}""".format(dtype=self.pixel_type)
         return s
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -683,7 +683,7 @@ class ImageSequenceND(_image_series):
         self.frame0 = np.array([frames[0], frames[2]])
         self.frame1 = np.array([frames[4], frames[6]])
         self.klass = pims.ImageSequenceND
-        self.kwargs = dict(dim_identifiers='tzc')
+        self.kwargs = dict(axes_identifiers='tzc')
         self.v = self.klass(self.filename, **self.kwargs)
         self.v.default_coords['c'] = 0
         self.expected_len = 3
@@ -709,8 +709,8 @@ class ImageSequenceND(_image_series):
         self.assertEqual(tzc, [47, 0, 34])
         tzc = pims.image_sequence.filename_to_indices('file_z4_c2.png')
         self.assertEqual(tzc, [0, 4, 2])
-        tzc = pims.image_sequence.filename_to_indices('file_x4_c2_y5_z1.png',
-                                                      ['x', 'y', 'z'])
+        tzc = pims.image_sequence.filename_to_indices('file_p4_c2_q5_r1.png',
+                                                      ['p', 'q', 'r'])
         self.assertEqual(tzc, [4, 5, 1])
 
     def test_sizeZ(self):
@@ -720,6 +720,45 @@ class ImageSequenceND(_image_series):
     def test_sizeC(self):
         self.check_skip()
         assert_equal(self.v.sizes['c'], self.expected_C)
+
+
+class ImageSequenceND_RGB(_image_series):
+    def check_skip(self):
+        pass
+
+    def setUp(self):
+        self.filepath = os.path.join(path, 'image_sequence3d')
+        self.filenames = ['file_t001_z001_c1.png',
+                          'file_t001_z002_c1.png',
+                          'file_t002_z001_c1.png',
+                          'file_t002_z002_c1.png',
+                          'file_t003_z001_c1.png',
+                          'file_t003_z002_c1.png']
+        shape = (10, 11, 3)
+        frames = save_dummy_png(self.filepath, self.filenames, shape)
+
+        self.filename = os.path.join(self.filepath, '*.png')
+        self.frame0 = np.array([frames[0][:, :, 0], frames[1][:, :, 0]])
+        self.frame1 = np.array([frames[2][:, :, 0], frames[3][:, :, 0]])
+        self.klass = pims.ImageSequenceND
+        self.kwargs = dict(axes_identifiers='tz')
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.v.default_coords['c'] = 0
+        self.expected_len = 3
+        self.expected_Z = 2
+        self.expected_C = 3
+        self.expected_shape = (2, 10, 11)
+
+    def test_sizeZ(self):
+        self.check_skip()
+        assert_equal(self.v.sizes['z'], self.expected_Z)
+
+    def test_sizeC(self):
+        self.check_skip()
+        assert_equal(self.v.sizes['c'], self.expected_C)
+
+    def tearDown(self):
+        clean_dummy_png(self.filepath, self.filenames)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Many images are RGB; ImageSequenceND was not working with these images. This addition checks the number of dimensions in the first frame and interprets the RGB dimension as the 'c' dimension. The rest of the functionality is the same as before.

It is not possible to output interleaved RGB images (axes order `yxc`) due to limitations of `FrameSequenceND`. If the user wants to output this, `bundle_axes` should be put to `cyx` and then use `np.rollaxis`. Downside is that in this way, the full RGB image is read 3 times, each time dropping all but one channel.

- API change: `dim_identifiers` is now `axes_identifiers`
- additionally renamed dimension to axes everywhere within `FrameSequenceND` scope
- add tests for ImageSequenceND with RGB (interleaved) PNGs