### PR TITLE
Do not flip and transpose TIFF images

### DIFF
--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -629,8 +629,8 @@ class TestTiffStack_pil(_tiff_image_series):
 
     def setUp(self):
         self.filename = os.path.join(path, 'stuck.tif')
-        self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy')).T[::-1]
-        self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy')).T[::-1]
+        self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
+        self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
         self.klass = pims.TiffStack_pil
         self.kwargs = dict()
         self.v = self.klass(self.filename, **self.kwargs)
@@ -644,8 +644,8 @@ class TestTiffStack_tifffile(_tiff_image_series):
 
     def setUp(self):
         self.filename = os.path.join(path, 'stuck.tif')
-        self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy')).T[::-1]
-        self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy')).T[::-1]
+        self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
+        self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
         self.klass = pims.TiffStack_tifffile
         self.kwargs = dict()
         self.v = self.klass(self.filename, **self.kwargs)

--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -127,8 +127,7 @@ class TiffStack_tifffile(FramesSequence):
 
     def get_frame(self, j):
         t = self._tiff[j]
-        # no idea why we need all of these flips...
-        data = np.flipud(t.asarray().T)
+        data = t.asarray()
         return Frame(self.process_func(data).astype(self._dtype),
                       frame_no=j, metadata=self._read_metadata(t))
 
@@ -402,7 +401,7 @@ class TiffStack_pil(FramesSequence):
             return None
         self.cur = self.im.tell()
         res = np.reshape(self.im.getdata(),
-                         self._im_sz).astype(self._dtype).T[::-1]
+                         self._im_sz).astype(self._dtype)
         return Frame(self.process_func(res), frame_no=j,
                      metadata=self._read_metadata())
 


### PR DESCRIPTION
as this results in a counterclockwise rotation by 90°. Apply to
TiffStack_pil and TiffStack_tifffile. Couldn't test TiffStack_libtiff since I
couldn't get it to work.

This should fix #164.