### PR TITLE
Fix Norpix repr

### DIFF
--- a/pims/norpix_reader.py
+++ b/pims/norpix_reader.py
@@ -234,6 +234,6 @@ Length: {count} frames
 Frame Shape: {w}w x {h}h
 Pixel Datatype: {dtype}""".format(filename=self.filename,
                                   count=len(self),
-                                  w=self.frame_shape[0],
-                                  h=self.frame_shape[1],
+                                  h=self.frame_shape[0],
+                                  w=self.frame_shape[1],
                                   dtype=self.pixel_type)

--- a/pims/tests/test_norpix.py
+++ b/pims/tests/test_norpix.py
@@ -75,6 +75,9 @@ class _common_norpix_sample_tests(object):
     def test_dump_times(self):
         assert isinstance(self.seq.dump_times_float(), np.ndarray)
 
+    def test_repr(self):
+        assert len(repr(self.seq))
+
 
 class test_norpix5_sample(_common_norpix_sample_tests, unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
Width and height were swapped in the Norpix reader's repr.

This also adds a smoke test for the repr.