### PR TITLE
FIX Height and depth safety checks for frame repr

### DIFF
--- a/pims/frame.py
+++ b/pims/frame.py
@@ -76,43 +76,67 @@ class Frame(ndarray):
 
     def _repr_html_(self):
         from jinja2 import Template
-        # Identify whether image is multichannel, convert to rgb if necessary
+        ndim = self.ndim
+        shape = self.shape
+        image = self
         try:
-            # if colors field exists, check if size agrees with image shape
             colors = self.metadata['colors']
-            is_multichannel = len(colors) == 1 or len(colors) == self.shape[0]         
+            if len(colors) != shape[0]:
+                colors = None
         except KeyError or AttributeError:
-            # if colors field does not exist, guess from image shape
             colors = None
-            is_multichannel = self.ndim > 2 and self.shape[0] < 5
-        if is_multichannel:
-            image = to_rgb(self, colors, False)
-            has_color_channels = True
+
+        # 2D, grayscale
+        if ndim == 2:
+            stack = False
+        # 2D, has colors attribute
+        elif ndim == 3 and colors is not None:
+            stack = False
+            image = to_rgb(image, colors, False)
+        # 2D, RGB
+        elif ndim == 3 and shape[2] in [3, 4]:
+            stack = False
+        # 2D, is multichannel
+        elif ndim == 3 and shape[0] < 5:  # guessing; could be small z-stack
+            stack = False
+            image = to_rgb(image, None, False)
+        # 3D, grayscale
+        elif ndim == 3:
+            stack = True
+        # 3D, has colors attribute
+        elif ndim == 4 and colors is not None:
+            stack = True
+            image = to_rgb(image, colors, False)
+        # 3D, RGB
+        elif ndim == 4 and shape[3] in [3, 4]:
+            stack = True
+        # 3D, is multichannel
+        elif ndim == 4 and shape[0] < 5:
+            stack = True
+            image = to_rgb(image, None, False)
         else:
-            image = self
-            has_color_channels = image.shape[-1] == 3 or image.shape[-1] == 4
+            # This exception will be caught by IPython and displayed
+            # as a FormatterWarning.
+            raise ValueError("No rich representation is available for "
+                             "frames of shape {0}".format(shape))
+
+        # Calculate display width
+        if stack: # z, y, x[, c]
+            frame_shape = shape[1:3]
+        else: # y, x[, c]
+            frame_shape = shape[:2]
+        width = WIDTH
+        if ((frame_shape[0] * width) // frame_shape[1]) > MAX_HEIGHT:
+            width = (frame_shape[1] * MAX_HEIGHT) // frame_shape[0]
+
         # If Frame is 2D, display as a plain image.
         # We have to build the image tag ourselves; _repr_html_ expects HTML.
-        if image.ndim == 2 or (image.ndim == 3 and has_color_channels):
-            width = WIDTH
-            if ((image.shape[0] * width) // image.shape[1]) > MAX_HEIGHT:
-                width = (image.shape[1] * MAX_HEIGHT) // image.shape[0]
+        if not stack:
             tag = Template('<img src="data:image/png;base64,{{data}}" '
                            'style="width: {{width}}" />')
             return tag.render(data=b64encode(_as_png(image,
                                                      width)).decode('utf-8'),
                               width=width)
         # If Frame is 3D, display as a scrollable stack.
-        elif image.ndim == 3 or (image.ndim == 4 and has_color_channels):
-            if image.shape[0] > MAX_STACK_DEPTH:          
-                raise ValueError("For 3D images, pims is limited to a stack "
-                                 "depth of {0}.".format(MAX_STACK_DEPTH))
-            width = WIDTH
-            if ((image.shape[1] * width) // image.shape[2]) > MAX_HEIGHT:
-                width = (image.shape[2] * MAX_HEIGHT) // image.shape[1]
-            return _scrollable_stack(image, width=width)
         else:
-            # This exception will be caught by IPython and displayed
-            # as a FormatterWarning.
-            raise ValueError("No rich representation is available for "
-                             "{0}-dimensional Frames".format(self.ndim))
+            return _scrollable_stack(image, width=width)


### PR DESCRIPTION
This solves issue #173

For rich IPython display of frames, the image was always resized so that width would be 512. Now there is an additional check that ensures height to stay below 512.

Also, for scrollable stacks, the max depth is set to 128 because of long waiting times of generating a large scrollable stack.