### PR TITLE
FIX Plots to frame pad mode

### DIFF
--- a/pims/display.py
+++ b/pims/display.py
@@ -440,7 +440,7 @@ def plots_to_frame(figures, width=512, close_fig=False, **imsave_kwargs):
         if (im.shape[0] != h) or (im.shape[1] != width):
             im = np.pad(im[:h, :width], ((0, max(0, h - im.shape[0])),
                                          (0, max(0, width - im.shape[1])),
-                                         (0, 0)), mode=b'constant')
+                                         (0, 0)), mode=str('constant'))
         frames.append(im)
 
     return Frame(np.array(frames))


### PR DESCRIPTION
This fixes a technical issue in python 3. `np.pad` takes a mode that is a string, which should be unicode in py3 and bytes in py2.7. Currently (using `b'constant'`) it failed in python 3, and together with `from __future__ import unicode_literals` it does need to be converted in Py2.7. The solution is a `str()` operation.

This fixes also `tp.annotate3d` under python 3.