### PR TITLE
Fix numpy 1.8 tests

### DIFF
--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -33,6 +33,13 @@ def _skip_if_no_libtiff():
         raise nose.SkipTest('libtiff not installed. Skipping.')
 
 
+def _skip_if_no_tifffile():
+    try:
+        import tifffile
+    except ImportError:
+        raise nose.SkipTest('tifffile not installed. Skipping.')
+
+
 def assert_image_equal(actual, expected):
     if np.issubdtype(actual.dtype, np.integer):
         assert_equal(actual, expected)
@@ -643,6 +650,7 @@ class TestTiffStack_tifffile(_tiff_image_series):
         pass
 
     def setUp(self):
+        _skip_if_no_tifffile()
         self.filename = os.path.join(path, 'stuck.tif')
         self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
         self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
@@ -697,6 +705,7 @@ class TestOpenFiles(unittest.TestCase):
         pims.open(os.path.join(path, 'bulk-water.mov'))
 
     def test_open_tiff(self):
+        _skip_if_no_tifffile()
         pims.open(os.path.join(path, 'stuck.tif'))
 
 

--- a/pims/tests/test_norpix.py
+++ b/pims/tests/test_norpix.py
@@ -39,7 +39,7 @@ class _common_norpix_sample_tests(object):
         hashes = set()  # Check that each frame is unique
         for i in range(len(s)):
             fr = s[i]
-            fhash = hash(np.array(fr).tobytes())
+            fhash = hash(np.array(fr).tostring())
             assert fhash not in hashes
             hashes.add(fhash)
 


### PR DESCRIPTION
Addresses #180. Also skips where appropriate when `tifffile` is not installed.