### PR TITLE
Rebase on slicerator

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
   - conda install -n testenv -c soft-matter --yes pyav tifffile
   - source activate testenv
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff; fi
-  - pip install jpype1;
+  - pip install slicerator jpype1;
   - python setup.py build_ext install
 
 

--- a/pims/api.py
+++ b/pims/api.py
@@ -1,8 +1,8 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
-from pims.base_frames import (FramesSequence, FramesSequenceND,
-                              SliceableIterable, pipeline)
+from slicerator import pipeline
+from pims.base_frames import FramesSequence, FramesSequenceND
 from pims.frame import Frame
 from pims.display import (export, play, scrollable_stack, to_rgb, normalize,
                           plot_to_frame, plots_to_frame)

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -10,7 +10,7 @@ import collections
 import itertools
 import functools
 import contextlib
-from slicerator import Slicerator
+from slicerator import slicerate
 from threading import Lock
 from .frame import Frame
 from abc import ABCMeta, abstractmethod, abstractproperty
@@ -150,10 +150,11 @@ class FramesSequence(FramesStream):
     Must be finite length.
 
     """
+    @slicerate()
     def __getitem__(self, key):
         """__getitem__ is handled by Slicerator. In all pims readers, the data
         returning function is get_frame."""
-        return Slicerator(self, 'get_frame')[key]
+        return self.get_frame(key)
 
     def __iter__(self):
         return iter(self[:])

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -63,7 +63,7 @@ class FramesStream(with_metaclass(ABCMeta, object)):
 
         Calls relevant classmethod.
         """
-        return type(self).class_ext()
+        return type(self).class_exts()
 
     def close(self):
         """

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -10,7 +10,7 @@ import collections
 import itertools
 import functools
 import contextlib
-from slicerator import slicerate, propagate, propagate_indexed
+from slicerator import Slicerator, propagate_attr, index_attr
 from threading import Lock
 from .frame import Frame
 from abc import ABCMeta, abstractmethod, abstractproperty
@@ -138,7 +138,7 @@ Pixel Datatype: {dtype}""".format(w=self.frame_shape[0],
                                   h=self.frame_shape[1],
                                   dtype=self.pixel_type)
 
-
+@Slicerator.from_class
 class FramesSequence(FramesStream):
     """Baseclass for wrapping data buckets that have random access.
 
@@ -150,8 +150,8 @@ class FramesSequence(FramesStream):
     Must be finite length.
 
     """
-    @slicerate(propagate=['frame_shape', 'pixel_type'],
-               propagate_indexed=['get_frame'])
+    propagate_attrs = ['frame_shape', 'pixel_type']
+
     def __getitem__(self, key):
         """__getitem__ is handled by Slicerator. In all pims readers, the data
         returning function is get_frame."""

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -10,7 +10,7 @@ import collections
 import itertools
 import functools
 import contextlib
-from slicerator import slicerate
+from slicerator import slicerate, propagate, propagate_indexed
 from threading import Lock
 from .frame import Frame
 from abc import ABCMeta, abstractmethod, abstractproperty
@@ -150,7 +150,8 @@ class FramesSequence(FramesStream):
     Must be finite length.
 
     """
-    @slicerate()
+    @slicerate(propagate=['frame_shape', 'pixel_type'],
+               propagate_indexed=['get_frame'])
     def __getitem__(self, key):
         """__getitem__ is handled by Slicerator. In all pims readers, the data
         returning function is get_frame."""

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -306,6 +306,8 @@ class BioformatsReader(FramesSequenceND):
             return {}
 
     class_priority = 5
+    propagate_attrs = ['frame_shape', 'pixel_type', 'metadata',
+                       'get_metadata_raw', 'reader_class_name']
 
     @property
     def pixel_type(self):

--- a/pims/cine.py
+++ b/pims/cine.py
@@ -13,7 +13,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 from pims.frame import Frame
-from pims.base_frames import FramesSequenceMappable
+from pims.base_frames import FramesSequence, propagate, propagate_indexed
 from pims.utils.misc import FileLocker
 import time
 import struct
@@ -208,7 +208,7 @@ SETUP_FIELDS = [
 ]
 
 
-class Cine(FramesSequenceMappable):
+class Cine(FramesSequence):
     """Read cine files
 
     Read cine files, the out put from Vision Research high-speed phantom
@@ -521,6 +521,7 @@ class Cine(FramesSequenceMappable):
 
     len = __len__
 
+    @propagate_indexed
     def get_time(self, i):
         '''Returm the time of frame i in seconds.'''
         # TODO: This is not guaranteed to be the actual time.
@@ -528,7 +529,7 @@ class Cine(FramesSequenceMappable):
         # The actual time is available from the timestamp tagged block,
         # which is read above.
         # See NorpixSeq for a timestamp API that solves this problem.
-        return float(self._map_index(i)) / self.frame_rate
+        return float(i) / self.frame_rate
 
     def get_fps(self):
         return self.frame_rate

--- a/pims/cine.py
+++ b/pims/cine.py
@@ -13,7 +13,7 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 from pims.frame import Frame
-from pims.base_frames import FramesSequence, propagate, propagate_indexed
+from pims.base_frames import FramesSequence, index_attr
 from pims.utils.misc import FileLocker
 import time
 import struct
@@ -233,8 +233,10 @@ class Cine(FramesSequence):
     # TODO: Unit tests using a small sample cine file.
     @classmethod
     def class_exts(cls):
-        return {'cine'} | super(Cine,
-                                cls).class_exts()
+        return {'cine'} | super(Cine, cls).class_exts()
+
+    propagate_attrs = ['frame_shape', 'pixel_type', 'filename', 'frame_rate',
+                       'get_fps', 'compression', 'cfa', 'off_set']
 
     def __init__(self, filename, process_func=None,
                  dtype=None, as_grey=False):
@@ -521,7 +523,7 @@ class Cine(FramesSequence):
 
     len = __len__
 
-    @propagate_indexed
+    @index_attr
     def get_time(self, i):
         '''Returm the time of frame i in seconds.'''
         # TODO: This is not guaranteed to be the actual time.

--- a/pims/norpix_reader.py
+++ b/pims/norpix_reader.py
@@ -10,7 +10,7 @@ import six
 from six.moves import range
 
 from pims.frame import Frame
-from pims.base_frames import FramesSequenceMappable
+from pims.base_frames import FramesSequence, propagate, propagate_indexed
 from pims.utils.misc import FileLocker
 import os, struct, itertools
 from warnings import warn
@@ -44,7 +44,7 @@ HEADER_FIELDS = [
 ]
 
 
-class NorpixSeq(FramesSequenceMappable):
+class NorpixSeq(FramesSequence):
     """Read Norpix sequence (.seq) files
 
     This is the native format of StreamPix software, owned by NorPix Inc.
@@ -180,6 +180,7 @@ class NorpixSeq(FramesSequenceMappable):
                             + self._image_bytes)
             return self._read_timestamp()
 
+    @propagate_indexed
     def get_time(self, i):
         """Return the time of frame i as a datetime instance.
 
@@ -187,15 +188,16 @@ class NorpixSeq(FramesSequenceMappable):
         was recorded will result in an offset. The .seq format does not
         store UTC or timezone information.
         """
-        return self._get_time(self._map_index(i))[1]
+        return self._get_time(i)[1]
 
+    @propagate_indexed
     def get_time_float(self, i):
         """Return the time of frame i as a floating-point number of seconds."""
-        return self._get_time(self._map_index(i))[0]
+        return self._get_time(i)[0]
 
     def dump_times_float(self):
         """Return all frame times in file, as an array of floating-point numbers."""
-        return np.array([self._get_time(i)[0] for i in self._all_indices()])
+        return np.array([self._get_time(i)[0] for i in range(len(self))])
 
     @property
     def filename(self):

--- a/pims/norpix_reader.py
+++ b/pims/norpix_reader.py
@@ -10,7 +10,7 @@ import six
 from six.moves import range
 
 from pims.frame import Frame
-from pims.base_frames import FramesSequence, propagate, propagate_indexed
+from pims.base_frames import FramesSequence, index_attr
 from pims.utils.misc import FileLocker
 import os, struct, itertools
 from warnings import warn
@@ -69,6 +69,10 @@ class NorpixSeq(FramesSequence):
     @classmethod
     def class_exts(cls):
         return {'seq'} | super(NorpixSeq, cls).class_exts()
+
+    propagate_attrs = ['frame_shape', 'pixel_type', 'get_time',
+                       'get_time_float', 'filename', 'width', 'height',
+                       'frame_rate']
 
     def __init__(self, filename, process_func=None, dtype=None, as_grey=False):
         super(NorpixSeq, self).__init__()
@@ -180,7 +184,7 @@ class NorpixSeq(FramesSequence):
                             + self._image_bytes)
             return self._read_timestamp()
 
-    @propagate_indexed
+    @index_attr
     def get_time(self, i):
         """Return the time of frame i as a datetime instance.
 
@@ -190,7 +194,7 @@ class NorpixSeq(FramesSequence):
         """
         return self._get_time(i)[1]
 
-    @propagate_indexed
+    @index_attr
     def get_time_float(self, i):
         """Return the time of frame i as a floating-point number of seconds."""
         return self._get_time(i)[0]

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -61,7 +61,7 @@ def clean_dummy_png(filepath, filenames):
         os.rmdir(filepath)
 
 
-class _image_single(unittest.TestCase):
+class _image_single(object):
     def check_skip(self):
         pass
 
@@ -313,12 +313,12 @@ class TestMultidimensional(unittest.TestCase):
         self.v.iter_axes = 't'
         for i in np.random.randint(0, 100, 10):
             assert_equal(self.v[i].frame_no, i)
-        self.v.iter_axes = 'zc'    
+        self.v.iter_axes = 'zc'
         for i in np.random.randint(0, 3*20, 10):
             assert_equal(self.v[i].frame_no, i)
 
     def test_metadata(self):
-        # if no metadata is provided by the reader, metadata should be {} 
+        # if no metadata is provided by the reader, metadata should be {}
         assert_equal(self.v[0].metadata, {})
 
         class MetadataReturningReader(pims.FramesSequenceND):
@@ -459,7 +459,7 @@ class _image_series(_image_single):
         list(self.v[[0, -1]])
 
 
-class _image_rgb(unittest.TestCase):
+class _image_rgb(_image_single):
     # Only include these tests for 2D RGB files.
     def test_greyscale_process_func(self):
         self.check_skip()
@@ -480,7 +480,7 @@ class _image_rgb(unittest.TestCase):
         self.assertEqual(ndim, 2)
 
 
-class TestVideo(_image_series, _image_rgb):
+class TestVideo(_image_series, _image_rgb, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_PyAV()
 
@@ -508,7 +508,7 @@ class _tiff_image_series(_image_series):
         assert_equal(m, d)
 
 
-class TestTiffStack_libtiff(_tiff_image_series):
+class TestTiffStack_libtiff(_tiff_image_series, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_libtiff()
 
@@ -524,7 +524,7 @@ class TestTiffStack_libtiff(_tiff_image_series):
         self.expected_len = 5
 
 
-class TestImageSequenceWithPIL(_image_series):
+class TestImageSequenceWithPIL(_image_series, unittest.TestCase):
     def setUp(self):
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
@@ -550,7 +550,7 @@ class TestImageSequenceWithPIL(_image_series):
         clean_dummy_png(self.filepath, self.filenames)
 
 
-class TestImageSequenceWithMPL(_image_series):
+class TestImageSequenceWithMPL(_image_series, unittest.TestCase):
     def setUp(self):
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
@@ -570,7 +570,7 @@ class TestImageSequenceWithMPL(_image_series):
     def tearDown(self):
         clean_dummy_png(self.filepath, self.filenames)
 
-class TestImageSequenceAcceptsList(_image_series):
+class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
     def setUp(self):
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
@@ -592,7 +592,7 @@ class TestImageSequenceAcceptsList(_image_series):
     def tearDown(self):
         clean_dummy_png(self.filepath, self.filenames)
 
-class TestImageSequenceNaturalSorting(_image_series):
+class TestImageSequenceNaturalSorting(_image_series, unittest.TestCase):
     def setUp(self):
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F1.png', 'T76S3F20.png',
@@ -623,7 +623,7 @@ class TestImageSequenceNaturalSorting(_image_series):
     def tearDown(self):
         clean_dummy_png(self.filepath, self.filenames)
 
-class TestTiffStack_pil(_tiff_image_series):
+class TestTiffStack_pil(_tiff_image_series, unittest.TestCase):
     def check_skip(self):
         pass
 
@@ -638,7 +638,7 @@ class TestTiffStack_pil(_tiff_image_series):
         self.expected_len = 5
 
 
-class TestTiffStack_tifffile(_tiff_image_series):
+class TestTiffStack_tifffile(_tiff_image_series, unittest.TestCase):
     def check_skip(self):
         pass
 
@@ -653,7 +653,7 @@ class TestTiffStack_tifffile(_tiff_image_series):
         self.expected_len = 5
 
 
-class TestSpeStack(_image_series):
+class TestSpeStack(_image_series, unittest.TestCase):
     def check_skip(self):
         pass
 
@@ -674,6 +674,9 @@ class TestSpeStack(_image_series):
                 d = pickle.load(p)
             else:
                 d = pickle.load(p, encoding="latin1")
+                # unpickling fails on Py3.4, Win7, 64-bit:
+                # UnpicklingError: the STRING opcode argument must be quoted
+
                 #spare4 is actually a byte array
                 d["spare4"] = d["spare4"].encode("latin1")
 
@@ -700,7 +703,7 @@ class TestOpenFiles(unittest.TestCase):
         pims.open(os.path.join(path, 'stuck.tif'))
 
 
-class ImageSequenceND(_image_series):
+class ImageSequenceND(_image_series, unittest.TestCase):
     def check_skip(self):
         pass
 
@@ -764,7 +767,7 @@ class ImageSequenceND(_image_series):
         assert_equal(self.v.sizes['c'], self.expected_C)
 
 
-class ImageSequenceND_RGB(_image_series):
+class ImageSequenceND_RGB(_image_series, unittest.TestCase):
     def check_skip(self):
         pass
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -408,13 +408,13 @@ class _image_series(_image_single):
         assert_image_equal(frame1, self.frame1)
 
     def test_pipeline_simple(self):
-        rescale = pims.pipeline()(_rescale)
+        rescale = pims.pipeline(_rescale)
         rescaled_v = rescale(self.v[:1])
 
         assert_image_equal(rescaled_v[0], _rescale(self.frame0))
 
     def test_pipeline_with_args(self):
-        color_channel = pims.pipeline()(_color_channel)
+        color_channel = pims.pipeline(_color_channel)
         red = color_channel(self.v, 0)
         green = color_channel(self.v, 1)
 
@@ -426,8 +426,8 @@ class _image_series(_image_single):
         assert_image_equal(red[0], _color_channel(self.frame0, 0))
 
     def test_composed_pipelines(self):
-        color_channel = pims.pipeline()(_color_channel)
-        rescale = pims.pipeline()(_rescale)
+        color_channel = pims.pipeline(_color_channel)
+        rescale = pims.pipeline(_rescale)
 
         composed = rescale(color_channel(self.v, 0))
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -401,13 +401,13 @@ class _image_series(_image_single):
         assert_image_equal(frame1, self.frame1)
 
     def test_pipeline_simple(self):
-        rescale = pims.pipeline(_rescale)
+        rescale = pims.pipeline()(_rescale)
         rescaled_v = rescale(self.v[:1])
 
         assert_image_equal(rescaled_v[0], _rescale(self.frame0))
 
     def test_pipeline_with_args(self):
-        color_channel = pims.pipeline(_color_channel)
+        color_channel = pims.pipeline()(_color_channel)
         red = color_channel(self.v, 0)
         green = color_channel(self.v, 1)
 
@@ -419,8 +419,8 @@ class _image_series(_image_single):
         assert_image_equal(red[0], _color_channel(self.frame0, 0))
 
     def test_composed_pipelines(self):
-        color_channel = pims.pipeline(_color_channel)
-        rescale = pims.pipeline(_rescale)
+        color_channel = pims.pipeline()(_color_channel)
+        rescale = pims.pipeline()(_rescale)
 
         composed = rescale(color_channel(self.v, 0))
 

--- a/pims/tests/test_norpix.py
+++ b/pims/tests/test_norpix.py
@@ -70,7 +70,7 @@ class _common_norpix_sample_tests(object):
         s = self.seq
         sli = s[4:]
         assert s.get_time(4) == sli.get_time(0)
-        assert s.get_time_float(4) == sli.dump_times_float()[0]
+        assert s.get_time_float(4) == list(sli.get_time_float[:])[0]
 
     def test_dump_times(self):
         assert isinstance(self.seq.dump_times_float(), np.ndarray)


### PR DESCRIPTION
This rebases the pims SliceableIterable on slicerator.

Test do not pass because of 2 issues:
- pypi doesn't have the latest version of slicerator yet (waiting for https://github.com/soft-matter/slicerator/pull/4)
- the pipelines do not work

The pipeline does raise an interesting issue: it only functions on `Slicerator`s while it should also function on the base `FramesSequence` object. So I should write a custom pims pipeline that also works on `FramesSequence` objects.

@danielballan wouldn't it make more sense to construct the Slicerator by subclassing it?