### PR TITLE
Drop PIL and Scipy dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,18 +4,18 @@ sudo: false
 matrix:
   include:
     - python: "2.7"
-      env: DEPS="numpy=1.9*"
+      env: DEPS="numpy=1.9*" DEPSSM="tifffile"
     - python: "2.7"
-      env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2"
+      env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
     - python: "3.4"
-      env: DEPS="numpy=1.9*"
+      env: DEPS="numpy=1.9*" DEPSSM="tifffile"
     - python: "3.4"
-      env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2"
+      env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
 
 install:
   - conda update --yes conda
   - conda create -n testenv --yes $DEPS nose pip python=$TRAVIS_PYTHON_VERSION
-  - conda install -n testenv -c soft-matter --yes pyav tifffile
+  - conda install -n testenv -c soft-matter --yes $DEPSSM
   - source activate testenv
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff; fi
   - pip install slicerator jpype1;

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,11 +4,11 @@ sudo: false
 matrix:
   include:
     - python: "2.7"
-      env: DEPS="numpy=1.9* scipy"
+      env: DEPS="numpy=1.9*"
     - python: "2.7"
       env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2"
     - python: "3.4"
-      env: DEPS="numpy=1.9* scipy"
+      env: DEPS="numpy=1.9*"
     - python: "3.4"
       env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,13 +1,20 @@
 language: python
 sudo: false
 
-python:
-  - 2.7
-  - 3.4
+matrix:
+  include:
+    - python: "2.7"
+      env: DEPS="numpy=1.9* scipy"
+    - python: "2.7"
+      env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2"
+    - python: "3.4"
+      env: DEPS="numpy=1.9* scipy"
+    - python: "3.4"
+      env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2"
 
 install:
   - conda update --yes conda
-  - conda create -n testenv --yes numpy=1.9* scipy nose "pillow<3" matplotlib scikit-image jinja2 pip python=$TRAVIS_PYTHON_VERSION
+  - conda create -n testenv --yes $DEPS nose pip python=$TRAVIS_PYTHON_VERSION
   - conda install -n testenv -c soft-matter --yes pyav tifffile
   - source activate testenv
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff; fi

--- a/pims/api.py
+++ b/pims/api.py
@@ -33,7 +33,7 @@ try:
     else:
         raise ImportError()
 except (ImportError, IOError):
-    Video = not_available("PyAV")
+    Video = not_available("PyAV and/or PIL/Pillow")
 
 import pims.tiff_stack
 from pims.tiff_stack import (TiffStack_pil, TiffStack_libtiff,

--- a/pims/display.py
+++ b/pims/display.py
@@ -15,7 +15,6 @@ except ImportError:
     ColorConverter = None
     mpl = None
     plt = None
-from PIL import Image
 
 
 def export(sequence, filename, rate=30, bitrate=None,
@@ -244,7 +243,10 @@ def scrollable_stack(sequence, width=512, normed=True):
 
 def _as_png(arr, width, normed=True):
     "Create a PNG image buffer from an array."
-    from PIL import Image
+    try:
+        from PIL import Image
+    except ImportError:
+        raise ImportError("This feature requires PIL/Pillow.")
     w = width  # for brevity
     h = arr.shape[0] * w // arr.shape[1]
     if normed:

--- a/pims/frame.py
+++ b/pims/frame.py
@@ -6,6 +6,7 @@ import six
 
 from numpy import ndarray, asarray
 from pims.display import _scrollable_stack, _as_png, to_rgb
+from warnings import warn
 
 
 WIDTH = 512  # width of rich display, in pixels
@@ -76,6 +77,10 @@ class Frame(ndarray):
 
     def _repr_html_(self):
         from jinja2 import Template
+        try:
+            from PIL import Image
+        except ImportError:
+            warn('Rich display in IPython requires PIL/Pillow.')
         ndim = self.ndim
         shape = self.shape
         image = self

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -17,7 +17,6 @@ from pims.base_frames import FramesSequence, FramesSequenceND
 from pims.frame import Frame
 from pims.utils.sort import natural_keys
 
-from PIL import Image
 # skimage.io.plugin_order() gives a nice hierarchy of implementations of imread.
 # If skimage is not available, go down our own hard-coded hierarchy.
 try:
@@ -111,8 +110,8 @@ class ImageSequence(FramesSequence):
 
     def imread(self, filename, **kwargs):
         if self._is_zipfile:
-            img = StringIO(self._zipfile.read(filename))
-            return np.array(Image.open(img))
+            file_handle = StringIO(self._zipfile.read(filename))
+            return imread(file_handle, **kwargs)
         else:
             return imread(filename, **kwargs)
 

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -25,7 +25,10 @@ except ImportError:
     try:
         from matplotlib.pyplot import imread
     except ImportError:
-        from scipy.ndimage import imread
+        try:
+            from scipy.ndimage import imread
+        except:
+            imread = None
 
 
 class ImageSequence(FramesSequence):
@@ -84,6 +87,11 @@ class ImageSequence(FramesSequence):
             self.kwargs = dict()
         else:
             self.kwargs = dict(plugin=plugin)
+
+        if imread is None:
+            raise ImportError("One of the following packages are required for "
+                              "using the ImageSequence reader: "
+                              "scipy, matplotlib or scikit-image.")
 
         self._is_zipfile = False
         self._zipfile = None

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -88,11 +88,6 @@ class ImageSequence(FramesSequence):
         else:
             self.kwargs = dict(plugin=plugin)
 
-        if imread is None:
-            raise ImportError("One of the following packages are required for "
-                              "using the ImageSequence reader: "
-                              "scipy, matplotlib or scikit-image.")
-
         self._is_zipfile = False
         self._zipfile = None
         self._get_files(path_spec)
@@ -117,6 +112,10 @@ class ImageSequence(FramesSequence):
         self.close()
 
     def imread(self, filename, **kwargs):
+        if imread is None:
+            raise ImportError("One of the following packages are required for "
+                              "using the ImageSequence reader: "
+                              "scipy, matplotlib or scikit-image.")
         if self._is_zipfile:
             file_handle = StringIO(self._zipfile.read(filename))
             return imread(file_handle, **kwargs)

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -19,6 +19,7 @@ except ImportError:
 def available():
     try:
         import av
+        from PIL import Image
     except ImportError:
         return False
     else:

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -14,7 +14,6 @@ import numpy as np
 from numpy.testing import (assert_equal, assert_allclose)
 from nose.tools import assert_true
 import pims
-from PIL import Image
 
 path, _ = os.path.split(os.path.abspath(__file__))
 path = os.path.join(path, 'data')
@@ -41,9 +40,9 @@ def _skip_if_no_tifffile():
 
 
 def _skip_if_no_imread():
-    if pims.imagesequence.imread is None:
+    if pims.image_sequence.imread is None:
         raise nose.SkipTest('ImageSequence requires either scipy, matplotlib or'
-                            'scikit-image. Skipping.')
+                            ' scikit-image. Skipping.')
 
 
 def _skip_if_no_skimage():
@@ -63,6 +62,7 @@ def assert_image_equal(actual, expected):
 
 
 def save_dummy_png(filepath, filenames, shape):
+    from PIL import Image
     if not os.path.isdir(filepath):
         os.mkdir(filepath)
     frames = []

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -40,6 +40,19 @@ def _skip_if_no_tifffile():
         raise nose.SkipTest('tifffile not installed. Skipping.')
 
 
+def _skip_if_no_imread():
+    if pims.imagesequence.imread is None:
+        raise nose.SkipTest('ImageSequence requires either scipy, matplotlib or'
+                            'scikit-image. Skipping.')
+
+
+def _skip_if_no_skimage():
+    try:
+        import skimage
+    except ImportError:
+        raise nose.SkipTest('skimage not installed. Skipping.')
+
+
 def assert_image_equal(actual, expected):
     if np.issubdtype(actual.dtype, np.integer):
         assert_equal(actual, expected)
@@ -180,6 +193,7 @@ def compare_slice_to_list(actual, expected):
 class TestRecursiveSlicing(unittest.TestCase):
 
     def setUp(self):
+        _skip_if_no_imread()
         class DemoReader(pims.ImageSequence):
             def imread(self, filename, **kwargs):
                 return np.array([[filename]])
@@ -533,6 +547,7 @@ class TestTiffStack_libtiff(_tiff_image_series, unittest.TestCase):
 
 class TestImageSequenceWithPIL(_image_series, unittest.TestCase):
     def setUp(self):
+        _skip_if_no_skimage()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
                           'T76S3F00003.png', 'T76S3F00004.png',
@@ -559,6 +574,7 @@ class TestImageSequenceWithPIL(_image_series, unittest.TestCase):
 
 class TestImageSequenceWithMPL(_image_series, unittest.TestCase):
     def setUp(self):
+        _skip_if_no_skimage()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
                           'T76S3F00003.png', 'T76S3F00004.png',
@@ -579,6 +595,7 @@ class TestImageSequenceWithMPL(_image_series, unittest.TestCase):
 
 class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
     def setUp(self):
+        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
                           'T76S3F00003.png', 'T76S3F00004.png',
@@ -601,6 +618,7 @@ class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
 
 class TestImageSequenceNaturalSorting(_image_series, unittest.TestCase):
     def setUp(self):
+        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F1.png', 'T76S3F20.png',
                      'T76S3F3.png', 'T76S3F4.png',
@@ -713,10 +731,8 @@ class TestOpenFiles(unittest.TestCase):
 
 
 class ImageSequenceND(_image_series, unittest.TestCase):
-    def check_skip(self):
-        pass
-
     def setUp(self):
+        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')
         self.filenames = ['file_t001_z001_c1.png',
                           'file_t001_z001_c2.png',
@@ -777,10 +793,8 @@ class ImageSequenceND(_image_series, unittest.TestCase):
 
 
 class ImageSequenceND_RGB(_image_series, unittest.TestCase):
-    def check_skip(self):
-        pass
-
     def setUp(self):
+        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')
         self.filenames = ['file_t001_z001_c1.png',
                           'file_t001_z002_c1.png',

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -52,6 +52,13 @@ def _skip_if_no_skimage():
         raise nose.SkipTest('skimage not installed. Skipping.')
 
 
+def _skip_if_no_PIL():
+    try:
+        from PIL import Image
+    except ImportError:
+        raise nose.SkipTest('PIL/Pillow not installed. Skipping.')
+
+
 def assert_image_equal(actual, expected):
     if np.issubdtype(actual.dtype, np.integer):
         assert_equal(actual, expected)
@@ -653,6 +660,7 @@ class TestTiffStack_pil(_tiff_image_series, unittest.TestCase):
         pass
 
     def setUp(self):
+        _skip_if_no_PIL()
         self.filename = os.path.join(path, 'stuck.tif')
         self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
         self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
@@ -711,6 +719,9 @@ class TestSpeStack(_image_series, unittest.TestCase):
 
 
 class TestOpenFiles(unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_PIL()
+
     def test_open_pngs(self):
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',

--- a/pims/tests/test_frame.py
+++ b/pims/tests/test_frame.py
@@ -2,9 +2,17 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
+import nose
 import numpy as np
 from pims.frame import Frame
 from nose.tools import assert_true, assert_equal
+
+
+def _skip_if_no_PIL():
+    try:
+        from PIL import Image
+    except ImportError:
+        raise nose.SkipTest('PIL/Pillow not installed. Skipping.')
 
 
 def test_scalar_casting():
@@ -25,6 +33,7 @@ def test_creation_md():
 
 
 def test_repr_html_():
+    _skip_if_no_PIL()
     # This confims a bugfix, where 16-bit images would raise
     # an error.
     Frame(10000*np.ones((50, 50), dtype=np.uint16))._repr_html_()


### PR DESCRIPTION
This makes PIL and scipy really optional, as a step up to #186 . I added a Travis mode with `numpy` only.

The PyAv reader is based on PIL too, so there is an extra check for that now.