### PR TITLE
FIX Two small fixes

### DIFF
--- a/pims/api.py
+++ b/pims/api.py
@@ -69,6 +69,12 @@ except (ImportError, IOError):
     Bioformats = not_available("JPype")
 
 
+try:
+    from pims_nd2 import ND2_Reader
+except ImportError:
+    ND2_Reader = not_available("pims_nd2")
+
+
 def open(sequence, process_func=None, dtype=None, as_grey=False, plugin=None):
     """Read a filename, list of filenames, or directory of image files into an
     iterable that returns images as numpy arrays.

--- a/pims/frame.py
+++ b/pims/frame.py
@@ -80,7 +80,7 @@ class Frame(ndarray):
         try:
             from PIL import Image
         except ImportError:
-            warn('Rich display in IPython requires PIL/Pillow.')
+            raise ImportError('Rich display in IPython requires PIL/Pillow.')
         ndim = self.ndim
         shape = self.shape
         image = self

--- a/pims/frame.py
+++ b/pims/frame.py
@@ -6,7 +6,6 @@ import six
 
 from numpy import ndarray, asarray
 from pims.display import _scrollable_stack, _as_png, to_rgb
-from warnings import warn
 
 
 WIDTH = 512  # width of rich display, in pixels


### PR DESCRIPTION
When PIL/Pillow is not found, `Frame._repr_html_` should raise an error, which is catched by IPython.

Also, I added an import to pims_nd2, for convenicence when pims_nd2 is installed.