### PR TITLE
Moviepy and ImageIO

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,21 +4,20 @@ sudo: false
 matrix:
   include:
     - python: "2.7"
-      env: DEPS="numpy=1.9*" DEPSSM="tifffile"
+      env: DEPS="numpy=1.9*" DEPSSM="tifffile" DEPSPIP="slicerator libtiff"
     - python: "2.7"
-      env: DEPS="numpy=1.9* scipy pillow matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
+      env: DEPS="numpy=1.9* scipy pillow matplotlib scikit-image jinja2" DEPSSM="pyav tifffile" DEPSPIP="slicerator libtiff moviepy imageio jpype1"
     - python: "3.4"
-      env: DEPS="numpy=1.9*" DEPSSM="tifffile"
+      env: DEPS="numpy=1.9*" DEPSSM="tifffile" DEPSPIP="slicerator"
     - python: "3.4"
-      env: DEPS="numpy=1.9* scipy pillow matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
+      env: DEPS="numpy=1.9* scipy pillow matplotlib scikit-image jinja2" DEPSSM="pyav tifffile" DEPSPIP="slicerator moviepy imageio jpype1"
 
 install:
   - conda update --yes conda
   - conda create -n testenv --yes $DEPS nose pip python=$TRAVIS_PYTHON_VERSION
   - conda install -n testenv -c soft-matter --yes $DEPSSM
   - source activate testenv
-  - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ]; then pip install libtiff; fi
-  - pip install slicerator jpype1;
+  - pip install $DEPSPIP
   - python setup.py build_ext install
 
 

--- a/pims/api.py
+++ b/pims/api.py
@@ -38,6 +38,19 @@ except (ImportError, IOError):
     PyAVVideoReader = not_available("PyAV and/or PIL/Pillow")
     Video = None
 
+
+try:
+    import pims.imageio_reader
+    if pims.imageio_reader.available():
+        ImageIOReader = pims.imageio_reader.ImageIOReader
+        if Video is None:
+            Video = ImageIOReader
+    else:
+        raise ImportError()
+except (ImportError, IOError):
+    MoviePyReader = not_available("ImageIO")
+
+
 try:
     import pims.moviepy_reader
     if pims.moviepy_reader.available():
@@ -50,7 +63,7 @@ except (ImportError, IOError):
     MoviePyReader = not_available("MoviePy")
 
 if Video is None:
-    Video = not_available("PyAV or MoviePy")
+    Video = not_available("PyAV, MoviePy, and ImageIO")
 
 import pims.tiff_stack
 from pims.tiff_stack import (TiffStack_pil, TiffStack_libtiff,

--- a/pims/api.py
+++ b/pims/api.py
@@ -27,6 +27,9 @@ def not_available(requirement):
             "This reader requires {0}.".format(requirement))
     return raiser
 
+if export is None:
+    export = not_available("PyAV or MoviePy")
+
 try:
     import pims.pyav_reader
     if pims.pyav_reader.available():
@@ -63,7 +66,7 @@ except (ImportError, IOError):
     MoviePyReader = not_available("MoviePy")
 
 if Video is None:
-    Video = not_available("PyAV, MoviePy, and ImageIO")
+    Video = not_available("PyAV, MoviePy, or ImageIO")
 
 import pims.tiff_stack
 from pims.tiff_stack import (TiffStack_pil, TiffStack_libtiff,

--- a/pims/api.py
+++ b/pims/api.py
@@ -30,11 +30,27 @@ def not_available(requirement):
 try:
     import pims.pyav_reader
     if pims.pyav_reader.available():
-        Video = pims.pyav_reader.PyAVVideoReader
+        PyAVVideoReader = pims.pyav_reader.PyAVVideoReader
+        Video = PyAVVideoReader
     else:
         raise ImportError()
 except (ImportError, IOError):
-    Video = not_available("PyAV and/or PIL/Pillow")
+    PyAVVideoReader = not_available("PyAV and/or PIL/Pillow")
+    Video = None
+
+try:
+    import pims.moviepy_reader
+    if pims.moviepy_reader.available():
+        MoviePyReader = pims.moviepy_reader.MoviePyReader
+        if Video is None:
+            Video = MoviePyReader
+    else:
+        raise ImportError()
+except (ImportError, IOError):
+    MoviePyReader = not_available("MoviePy")
+
+if Video is None:
+    Video = not_available("PyAV or MoviePy")
 
 import pims.tiff_stack
 from pims.tiff_stack import (TiffStack_pil, TiffStack_libtiff,

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -299,11 +299,8 @@ class BioformatsReader(FramesSequenceND):
     """
     @classmethod
     def class_exts(cls):
-        try:
-            return {'lsm', 'ipl', 'dm3', 'seq', 'nd2', 'ics', 'ids',
-                    'mov', 'ipw', 'tif', 'tiff', 'jpg', 'bmp', 'lif', 'lei'}
-        except AttributeError:
-            return {}
+        return {'lsm', 'ipl', 'dm3', 'seq', 'nd2', 'ics', 'ids',
+                'ipw', 'tif', 'tiff', 'jpg', 'bmp', 'lif', 'lei'}
 
     class_priority = 5
     propagate_attrs = ['frame_shape', 'pixel_type', 'metadata',

--- a/pims/display.py
+++ b/pims/display.py
@@ -8,6 +8,7 @@ import tempfile
 from io import BytesIO
 from base64 import b64encode
 from contextlib import contextmanager
+import warnings
 
 try:
     from matplotlib.colors import ColorConverter
@@ -24,7 +25,9 @@ except ImportError:
     av = None
 
 try:
-    from moviepy.editor import VideoClip
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from moviepy.editor import VideoClip
 except ImportError:
     VideoClip = None
     

--- a/pims/display.py
+++ b/pims/display.py
@@ -136,8 +136,10 @@ def play(sequence, rate=30, bitrate=None,
         display(repr_video(temp.name, 'x-webm'))
 
 
-def export_moviepy(sequence, filename, rate=30, codec='mpeg4',
-                   autoscale=True, **kwargs):
+def export_moviepy(sequence, filename, rate=30, bitrate=None, width=None,
+                   height=None, codec='mpeg4', format='yuv420p', 
+                   autoscale=True, quality=None, verbose=True,
+                   ffmpeg_params=None):
     """Export a sequence of images as a standard video file.
 
     N.B. If the quality and detail are insufficient, increase the
@@ -152,25 +154,59 @@ def export_moviepy(sequence, filename, rate=30, codec='mpeg4',
         name of output file
     rate : integer, optional
         frame rate of output file, 30 by default
+    bitrate : integer or string, optional
+        Video bitrate is crudely guessed if None is given.
+    width : integer, optional
+        By default, set the width of the images.
+    height : integer, optional
+        By default, set the  height of the images. If width is specified
+        and height is not, the height is autoscaled to maintain the aspect
+        ratio.
     codec : string, optional
         a valid video encoding, 'mpeg4' by default
+    format: string, optional
+        Video stream format, 'yuv420p' by default.
+    quality: integer or string, optional
+        Use this for variable bitrates. 1 = high quality, 5 = default.
     autoscale : boolean, optional
         Linearly rescale the brightness to use the full gamut of black to
         white values. True by default.
+    verbose : boolean, optional
+        Determines whether MoviePy will print progress. True by default.
+    ffmpeg_params : dictionary, optional
+        Dictionary of parameters that will be passed to ffmpeg. By default
+        {'pixel_format': str(format), 'qscale:v': str(quality)}
+
+    See Also
+    --------
+    http://zulko.github.io/moviepy/ref/VideoClip/VideoClip.html#moviepy.video.VideoClip.VideoClip.write_videofile
     """
     if VideoClip is None:
         raise ImportError('The MoviePy exporter requires moviepy to work.')
-    _kwargs = dict(fps=rate, codec=codec, ffmpeg_params=['-qscale:v', '5'])
-    _kwargs.update(kwargs)
+
+    if ffmpeg_params is None:
+        ffmpeg_params = dict()
+    if quality is not None:
+        ffmpeg_params['qscale:v'] = str(quality)
+    if format is not None:
+        ffmpeg_params['pixel_format'] = str(format)
+    if bitrate is None:
+        bitrate = _estimate_bitrate(sequence[0].shape, rate)
+
+    _ffmpeg_params = []
+    [_ffmpeg_params.extend(['-' + key, ffmpeg_params[key]])
+     for key in ffmpeg_params]
 
     if rate < 10:
-        raise ValueError('Framerate must be greater than 10, else there will '
-                         'be playback issues.')
+        warnings.warn('Framerates lower than 10 may give playback issues.')
 
     clip = VideoClip(lambda t: _to_rgb_uint8(sequence[int(round(t*rate))],
                                              autoscale))
     clip.duration = (len(sequence) - 1) / rate
-    clip.write_videofile(filename, **_kwargs)
+    if not (height is None and width is None):
+        clip = clip.resize(height=height, width=width)
+    clip.write_videofile(filename, rate, codec, str(bitrate), audio=False,
+                         verbose=verbose, ffmpeg_params=_ffmpeg_params)
 
 if av is not None:
     export = export_pyav
@@ -313,8 +349,12 @@ def _to_rgb_uint8(image, autoscale):
         image = (normalize(image) * 255).astype(np.uint8)
     elif image.dtype is not np.uint8:
         if np.issubdtype(image.dtype, np.integer):
-            image = image / np.iinfo(image.dtype).max
-            image = (image * 255).astype(np.uint8)
+            # many cameras have 12-bit images stored as 16-bit
+            if image.dtype is np.uint16 and image.max() < 2**12:
+                max_value = 2**12 - 1
+            else:
+                max_value = np.iinfo(image.dtype).max
+            image = (image / max_value * 255).astype(np.uint8)
         else:
             image = (image * 255).astype(np.uint8)
 

--- a/pims/display.py
+++ b/pims/display.py
@@ -349,11 +349,10 @@ def _to_rgb_uint8(image, autoscale):
         image = (normalize(image) * 255).astype(np.uint8)
     elif image.dtype is not np.uint8:
         if np.issubdtype(image.dtype, np.integer):
-            # many cameras have 12-bit images stored as 16-bit
-            if image.dtype is np.uint16 and image.max() < 2**12:
+            max_value = np.iinfo(image.dtype).max
+            # sometimes 12-bit images are stored as unsigned 16-bit
+            if max_value == 2**16 - 1 and image.max() < 2**12:
                 max_value = 2**12 - 1
-            else:
-                max_value = np.iinfo(image.dtype).max
             image = (image / max_value * 255).astype(np.uint8)
         else:
             image = (image * 255).astype(np.uint8)

--- a/pims/display.py
+++ b/pims/display.py
@@ -212,6 +212,8 @@ if av is not None:
     export = export_pyav
 elif VideoClip is not None:
     export = export_moviepy
+else:
+    export = None
 
 def repr_video(fname, mimetype):
     """Load the video in the file `fname`, with given mimetype,

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -26,8 +26,7 @@ class ImageIOReader(FramesSequence):
                 'psd', 'ras', 'raw', 'sgi', 'targa', 'fi_tiff', 'wbmp', 'webp',
                 'xbm', 'xpm', 'ico', 'gif', 'dicom', 'npz', 'fits', 'itk',
                 'gdal', 'dummy', 'gif', 'ffmpeg', 'avbin', 'swf', 'fits',
-                'gdal', 'mov', 'mp4', 'avi', 'mpeg',
-                'wmv'} | super(ImageIOReader, cls).class_exts()
+                'gdal', 'mov', 'mp4', 'avi', 'mpeg', 'wmv', 'mkv'}
 
     def __init__(self, filename, **kwargs):
         if imageio is None:
@@ -55,6 +54,10 @@ class ImageIOReader(FramesSequence):
         for i in range(len(self)):
             frame = next(iterable)
             yield Frame(frame, frame_no=i, metadata=frame.meta)
+
+    @property
+    def frame_rate(self):
+        return self.get_metadata()['fps']
 
     @property
     def frame_shape(self):

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -1,0 +1,46 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import six
+
+from pims.base_frames import FramesSequence
+from pims.frame import Frame
+
+try:
+    import imageio
+except ImportError:
+    imageio = None
+
+
+def available():
+    return imageio is not None
+
+class ImageIOReader(FramesSequence):
+    def __init__(self, filename):
+        if imageio is None:
+            raise ImportError('The ImageIOReader requires imageio to work.')
+        self.reader = imageio.get_reader(filename)
+        self.filename = filename
+        self._len = len(self.reader)
+
+        first_frame = self.get_frame(0)
+        self._shape = first_frame.shape
+        self._dtype = first_frame.dtype
+
+    def get_frame(self, i):
+        return Frame(self.reader.get_data(i), frame_no=i,
+                     metadata=self.reader.get_meta_data(i))
+
+    def __len__(self):
+        return self._len
+
+    @property
+    def frame_shape(self):
+        return self._shape
+
+    @property
+    def pixel_type(self):
+        return self._dtype  
+
+    def close(self):
+        self.reader.close()

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -39,9 +39,10 @@ class ImageIOReader(FramesSequence):
         return self._len
 
     def __iter__(self):
-        return map(lambda x: Frame(x[1], frame_no=x[0],
-                                   metadata=dict(x[1].meta)),
-                   enumerate(self.reader.iter_data()))
+        iterable = self.reader.iter_data()
+        for i in range(len(self)):
+            frame = next(iterable)
+            yield Frame(frame, frame_no=i, metadata=frame.meta)
 
     @property
     def frame_shape(self):

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -39,10 +39,9 @@ class ImageIOReader(FramesSequence):
         return self._len
 
     def __iter__(self):
-        iterable = self.reader.iter_data()
-        for i in range(len(self)):
-            frame = next(iterable)
-            yield Frame(frame, frame_no=i, metadata=frame.meta)
+        return map(lambda x: Frame(x[1], frame_no=x[0],
+                                   metadata=dict(x[1].meta)),
+                   enumerate(self.reader.iter_data()))
 
     @property
     def frame_shape(self):

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -17,6 +17,18 @@ def available():
 
 
 class ImageIOReader(FramesSequence):
+    class_priority = 3
+    @classmethod
+    def class_exts(cls):
+        return {'tiff', 'bmp', 'cut', 'dds', 'exr', 'g3', 'hdr', 'iff', 'j2k',
+                'jng', 'jp2', 'jpeg', 'jpg', 'koala', 'pbm', 'pbmraw', 'pcd',
+                'pcx', 'pfm', 'pgm', 'pgmraw', 'pict', 'png', 'ppm', 'ppmraw',
+                'psd', 'ras', 'raw', 'sgi', 'targa', 'fi_tiff', 'wbmp', 'webp',
+                'xbm', 'xpm', 'ico', 'gif', 'dicom', 'npz', 'fits', 'itk',
+                'gdal', 'dummy', 'gif', 'ffmpeg', 'avbin', 'swf', 'fits',
+                'gdal', 'mov', 'mp4', 'avi', 'mpeg',
+                'wmv'} | super(ImageIOReader, cls).class_exts()
+
     def __init__(self, filename, **kwargs):
         if imageio is None:
             raise ImportError('The ImageIOReader requires imageio to work.')

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -15,24 +15,34 @@ except ImportError:
 def available():
     return imageio is not None
 
+
 class ImageIOReader(FramesSequence):
-    def __init__(self, filename):
+    def __init__(self, filename, **kwargs):
         if imageio is None:
             raise ImportError('The ImageIOReader requires imageio to work.')
-        self.reader = imageio.get_reader(filename)
+        self.reader = imageio.get_reader(filename, **kwargs)
         self.filename = filename
-        self._len = len(self.reader)
+        self._len = self.reader.get_length()
 
         first_frame = self.get_frame(0)
         self._shape = first_frame.shape
         self._dtype = first_frame.dtype
 
     def get_frame(self, i):
-        return Frame(self.reader.get_data(i), frame_no=i,
-                     metadata=self.reader.get_meta_data(i))
+        frame = self.reader.get_data(i)
+        return Frame(frame, frame_no=i, metadata=frame.meta)
+
+    def get_metadata(self):
+        return self.reader.get_meta_data(None)
 
     def __len__(self):
         return self._len
+
+    def __iter__(self):
+        iterable = self.reader.iter_data()
+        for i in range(len(self)):
+            frame = next(iterable)
+            yield Frame(frame, frame_no=i, metadata=frame.meta)
 
     @property
     def frame_shape(self):
@@ -40,7 +50,7 @@ class ImageIOReader(FramesSequence):
 
     @property
     def pixel_type(self):
-        return self._dtype  
+        return self._dtype
 
     def close(self):
         self.reader.close()

--- a/pims/moviepy_reader.py
+++ b/pims/moviepy_reader.py
@@ -5,11 +5,18 @@ import six
 
 from pims.base_frames import FramesSequence
 from pims.frame import Frame
+import warnings
 
 try:
-    from moviepy.editor import VideoFileClip
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        from moviepy.editor import VideoFileClip
 except ImportError:
     VideoFileClip = None
+
+
+def available():
+    return VideoFileClip is not None
 
 
 class MoviePyReader(FramesSequence):

--- a/pims/moviepy_reader.py
+++ b/pims/moviepy_reader.py
@@ -1,0 +1,40 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import six
+
+from pims.base_frames import FramesSequence
+from pims.frame import Frame
+
+try:
+    from moviepy.editor import VideoFileClip
+except ImportError:
+    VideoFileClip = None
+
+
+class MoviePyReader(FramesSequence):
+    def __init__(self, filename):
+        if VideoFileClip is None:
+            raise ImportError('The MoviePyReader requires moviepy to work.')
+        self.clip = VideoFileClip(filename)
+        self.filename = filename
+        self._fps = self.clip.fps
+        self._len = int(self.clip.fps * self.clip.end)
+
+        first_frame = self.clip.get_frame(0)
+        self._shape = first_frame.shape
+        self._dtype = first_frame.dtype
+
+    def get_frame(self, i):
+        return Frame(self.clip.get_frame(i / self._fps))
+
+    def __len__(self):
+        return self._len
+
+    @property
+    def frame_shape(self):
+        return self._shape
+
+    @property
+    def pixel_type(self):
+        return self._dtype  

--- a/pims/moviepy_reader.py
+++ b/pims/moviepy_reader.py
@@ -23,8 +23,7 @@ class MoviePyReader(FramesSequence):
     class_priority = 4
     @classmethod
     def class_exts(cls):
-        return {'mov', 'mp4', 'avi', 'mpeg',
-                'wmv'} | super(MoviePyReader, cls).class_exts()
+        return {'mov', 'mp4', 'avi', 'mpeg', 'wmv', 'mkv'}
     def __init__(self, filename):
         if VideoFileClip is None:
             raise ImportError('The MoviePyReader requires moviepy to work.')
@@ -46,6 +45,10 @@ class MoviePyReader(FramesSequence):
     @property
     def frame_shape(self):
         return self._shape
+
+    @property
+    def frame_rate(self):
+        return self._fps
 
     @property
     def pixel_type(self):

--- a/pims/moviepy_reader.py
+++ b/pims/moviepy_reader.py
@@ -20,6 +20,11 @@ def available():
 
 
 class MoviePyReader(FramesSequence):
+    class_priority = 4
+    @classmethod
+    def class_exts(cls):
+        return {'mov', 'mp4', 'avi', 'mpeg',
+                'wmv'} | super(MoviePyReader, cls).class_exts()
     def __init__(self, filename):
         if VideoFileClip is None:
             raise ImportError('The MoviePyReader requires moviepy to work.')

--- a/pims/moviepy_reader.py
+++ b/pims/moviepy_reader.py
@@ -33,7 +33,7 @@ class MoviePyReader(FramesSequence):
         self._dtype = first_frame.dtype
 
     def get_frame(self, i):
-        return Frame(self.clip.get_frame(i / self._fps))
+        return Frame(self.clip.get_frame(i / self._fps), frame_no=i)
 
     def __len__(self):
         return self._len

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -12,18 +12,13 @@ from pims.frame import Frame
 
 try:
     import av
+    from PIL import Image
 except ImportError:
     av = None
 
 
 def available():
-    try:
-        import av
-        from PIL import Image
-    except ImportError:
-        return False
-    else:
-        return True
+    return av is not None
 
 
 class PyAVVideoReader(FramesSequence):

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -56,6 +56,7 @@ class PyAVVideoReader(FramesSequence):
     >>> frame_count = len(video) # Number of frames in video
     >>> frame_shape = video.frame_shape # Pixel dimensions of video
     """
+    class_priority = 2
     @classmethod
     def class_exts(cls):
         return {'mov', 'avi',

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -28,6 +28,18 @@ def _skip_if_no_PyAV():
         raise nose.SkipTest('PyAV not found. Skipping.')
 
 
+def _skip_if_no_MoviePy():
+    import pims.moviepy_reader
+    if not pims.moviepy_reader.available():
+        raise nose.SkipTest('MoviePy not found. Skipping.')
+
+
+def _skip_if_no_ImageIO():
+    import pims.imageio_reader
+    if not pims.imageio_reader.available():
+        raise nose.SkipTest('ImageIO not found. Skipping.')
+
+
 def _skip_if_no_libtiff():
     try:
         import libtiff
@@ -119,6 +131,8 @@ class _image_single(object):
         # simple smoke test, values not checked
         repr(self.v)
 
+
+class _deprecated_functions(object):
     def test_dtype_conversion(self):
         self.check_skip()
         v8 = self.klass(self.filename, dtype='uint8', **self.kwargs)
@@ -511,7 +525,8 @@ class _image_rgb(_image_single):
         self.assertEqual(ndim, 2)
 
 
-class TestVideo(_image_series, _image_rgb, unittest.TestCase):
+class TestVideo_PyAV(_image_series, _image_rgb, _deprecated_functions,
+                     unittest.TestCase):
     def check_skip(self):
         _skip_if_no_PyAV()
 
@@ -520,14 +535,46 @@ class TestVideo(_image_series, _image_rgb, unittest.TestCase):
         self.filename = os.path.join(path, 'bulk-water.mov')
         self.frame0 = np.load(os.path.join(path, 'bulk-water_frame0.npy'))
         self.frame1 = np.load(os.path.join(path, 'bulk-water_frame1.npy'))
-        self.klass = pims.Video
+        self.klass = pims.PyAVVideoReader
         self.kwargs = dict()
         self.v = self.klass(self.filename, **self.kwargs)
-        self.expected_shape = (640, 424, 3)
+        self.expected_shape = (640, 424, 3)  # (x, y), wrong convention?
         self.expected_len = 480
 
 
-class _tiff_image_series(_image_series):
+class TestVideo_ImageIO(_image_series, unittest.TestCase):
+    def check_skip(self):
+        _skip_if_no_ImageIO()
+
+    def setUp(self):
+        _skip_if_no_ImageIO()
+        self.filename = os.path.join(path, 'bulk-water.mov')
+        self.frame0 = np.load(os.path.join(path, 'bulk-water_frame0.npy'))
+        self.frame1 = np.load(os.path.join(path, 'bulk-water_frame1.npy'))
+        self.klass = pims.ImageIOReader
+        self.kwargs = dict()
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = (424, 640, 3)
+        self.expected_len = 480
+
+
+class TestVideo_MoviePy(_image_series, unittest.TestCase):
+    def check_skip(self):
+        _skip_if_no_MoviePy()
+
+    def setUp(self):
+        _skip_if_no_MoviePy()
+        self.filename = os.path.join(path, 'bulk-water.mov')
+        self.frame0 = np.load(os.path.join(path, 'bulk-water_frame0.npy'))
+        self.frame1 = np.load(os.path.join(path, 'bulk-water_frame1.npy'))
+        self.klass = pims.MoviePyReader
+        self.kwargs = dict()
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = (424, 640, 3)
+        self.expected_len = 480
+
+
+class _tiff_image_series(_image_series, _deprecated_functions):
     def test_metadata(self):
         m = self.v[0].metadata
         if sys.version_info.major < 3:
@@ -539,7 +586,8 @@ class _tiff_image_series(_image_series):
         assert_equal(m, d)
 
 
-class TestTiffStack_libtiff(_tiff_image_series, unittest.TestCase):
+class TestTiffStack_libtiff(_tiff_image_series, _deprecated_functions,
+                            unittest.TestCase):
     def check_skip(self):
         _skip_if_no_libtiff()
 
@@ -555,7 +603,8 @@ class TestTiffStack_libtiff(_tiff_image_series, unittest.TestCase):
         self.expected_len = 5
 
 
-class TestImageSequenceWithPIL(_image_series, unittest.TestCase):
+class TestImageSequenceWithPIL(_image_series, _deprecated_functions,
+                               unittest.TestCase):
     def setUp(self):
         _skip_if_no_skimage()
         self.filepath = os.path.join(path, 'image_sequence')
@@ -593,7 +642,8 @@ class TestImageSequenceWithPIL(_image_series, unittest.TestCase):
         os.rmdir(self.tempdir)
 
 
-class TestImageSequenceWithMPL(_image_series, unittest.TestCase):
+class TestImageSequenceWithMPL(_image_series, _deprecated_functions,
+                               unittest.TestCase):
     def setUp(self):
         _skip_if_no_skimage()
         self.filepath = os.path.join(path, 'image_sequence')
@@ -614,7 +664,8 @@ class TestImageSequenceWithMPL(_image_series, unittest.TestCase):
     def tearDown(self):
         clean_dummy_png(self.filepath, self.filenames)
 
-class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
+class TestImageSequenceAcceptsList(_image_series, _deprecated_functions,
+                                   unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
@@ -637,7 +688,8 @@ class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
     def tearDown(self):
         clean_dummy_png(self.filepath, self.filenames)
 
-class TestImageSequenceNaturalSorting(_image_series, unittest.TestCase):
+class TestImageSequenceNaturalSorting(_image_series, _deprecated_functions,
+                                      unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
@@ -669,7 +721,8 @@ class TestImageSequenceNaturalSorting(_image_series, unittest.TestCase):
     def tearDown(self):
         clean_dummy_png(self.filepath, self.filenames)
 
-class TestTiffStack_pil(_tiff_image_series, unittest.TestCase):
+class TestTiffStack_pil(_tiff_image_series, _deprecated_functions,
+                        unittest.TestCase):
     def check_skip(self):
         pass
 
@@ -685,7 +738,8 @@ class TestTiffStack_pil(_tiff_image_series, unittest.TestCase):
         self.expected_len = 5
 
 
-class TestTiffStack_tifffile(_tiff_image_series, unittest.TestCase):
+class TestTiffStack_tifffile(_tiff_image_series, _deprecated_functions,
+                             unittest.TestCase):
     def check_skip(self):
         pass
 
@@ -701,7 +755,8 @@ class TestTiffStack_tifffile(_tiff_image_series, unittest.TestCase):
         self.expected_len = 5
 
 
-class TestSpeStack(_image_series, unittest.TestCase):
+class TestSpeStack(_image_series, _deprecated_functions,
+                   unittest.TestCase):
     def check_skip(self):
         pass
 
@@ -755,7 +810,7 @@ class TestOpenFiles(unittest.TestCase):
         pims.open(os.path.join(path, 'stuck.tif'))
 
 
-class ImageSequenceND(_image_series, unittest.TestCase):
+class ImageSequenceND(_image_series, _deprecated_functions, unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')
@@ -817,7 +872,8 @@ class ImageSequenceND(_image_series, unittest.TestCase):
         assert_equal(self.v.sizes['c'], self.expected_C)
 
 
-class ImageSequenceND_RGB(_image_series, unittest.TestCase):
+class ImageSequenceND_RGB(_image_series, _deprecated_functions,
+                          unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')


### PR DESCRIPTION
This contains some older work that I am already using for some time now:

- video readers via ImageIO and MoviePy , both packages have different implementations of an ffmpeg-based video reader via pipes
- video exporter via moviepy, similar api as the PyAv exporter
- tests for the readers

One thing, the PyAV reader seems to be tested with an expected shape that is (x, y) in stead of the conventional (y, x). @danielballan  was this intentional?