### PR TITLE
FIX Pillow 3.0.0 compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
     - python: "2.7"
       env: DEPS="numpy=1.9*" DEPSSM="tifffile"
     - python: "2.7"
-      env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
+      env: DEPS="numpy=1.9* scipy pillow matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
     - python: "3.4"
       env: DEPS="numpy=1.9*" DEPSSM="tifffile"
     - python: "3.4"
-      env: DEPS="numpy=1.9* scipy pillow<3 matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
+      env: DEPS="numpy=1.9* scipy pillow matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
 
 install:
   - conda update --yes conda

--- a/README.md
+++ b/README.md
@@ -124,18 +124,6 @@ and/or
 which will cause PyAV to use the your operating system's version of the
 library.
 
-### Pillow
-
-If you get the following error message:
-
-    File ".../PIL/TiffImagePlugin.py", line 608, in save
-    TypeError: object of type 'int' has no len()
-
-This is a known issue having to do with Pillow 3.0.0. This is solved with a
-downgrade to Pillow 2.9.0.
-
-    pip install pillow==2.9.0
-
 Updating Your Installation
 --------------------------
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -29,10 +29,6 @@ active development, with the latest tested code, use the development channel.
    conda config --add channels soft-matter
    conda install -c soft-matter/channel/dev pims
 
-.. note::
-
-   There is a known issue with Pillow version 3.0.0. Check your Pillow version
-   and if necessary, downgrade to 2.9.0.
 
 pip
 ---

--- a/pims/display.py
+++ b/pims/display.py
@@ -440,20 +440,19 @@ def plots_to_frame(figures, width=512, close_fig=False, bbox_inches=None):
         raise ValueError('Use plot_to_frame for single figures, or supply '
                          'an iterable of figures to plots_to_frame.')
 
-    # render first image to calculate the correct dpi and image size
-    size = plot_to_frame(figures[0], 100).shape
-    dpi = width * 100 / size[1]
-    h = int(width * size[0] / size[1])
     width = int(width)
+    h = None
 
     frames = []
     for n, fig in enumerate(figures):
-        im = plot_to_frame(fig, dpi, close_fig)
-        # make the image the same size as the first image
-        if (im.shape[0] != h) or (im.shape[1] != width):
-            im = np.pad(im[:h, :width], ((0, max(0, h - im.shape[0])),
-                                         (0, max(0, width - im.shape[1])),
-                                         (0, 0)), mode=str('constant'))
+        im = plot_to_frame(fig, width, close_fig, bbox_inches)
+        if h is None:
+            h = im.shape[0]
+        else:
+            # make the image the same size as the first image
+            if im.shape[0] != h:
+                im = np.pad(im[:h], ((0, max(0, h - im.shape[0])), (0, 0),
+                                     (0, 0)), mode=str('constant'))
         frames.append(im)
 
     return Frame(np.array(frames))

--- a/pims/display.py
+++ b/pims/display.py
@@ -376,14 +376,16 @@ def to_rgb(image, colors=None, normed=True):
     return result
 
 
-def plot_to_frame(fig, dpi, close_fig=False):
+def plot_to_frame(fig, width=512, close_fig=False, bbox_inches=None):
     """ Renders a matplotlib figure or axes object into a numpy array
     containing RGBA data of the rendered image.
 
     Parameters
     ----------
     fig : matplotlib Figure or Axes object
-    dpi : number, dots per inch used in figure rendering
+    width : integer
+    close_fig : boolean
+    bbox_inches :
 
     Returns
     -------
@@ -396,18 +398,26 @@ def plot_to_frame(fig, dpi, close_fig=False):
         fig = fig.figure
 
     agg = fig.canvas.switch_backends(mpl.backends.backend_agg.FigureCanvasAgg)
+    original_bbox = fig.bbox_inches
+    if bbox_inches is not None:
+        fig.bbox_inches = bbox_inches
+
     original_dpi = fig.dpi
-    fig.dpi = dpi
+    orig_width, orig_height = agg.get_width_height()
+    fig.dpi = original_dpi * width / orig_width
+
     buf, (width, height) = agg.print_to_buffer()
     image = np.frombuffer(buf, dtype=np.uint8).reshape(height, width, 4)
+
+    fig.dpi = original_dpi
+    if bbox_inches is not None:
+        fig.bbox_inches = original_bbox
     if close_fig:
         plt.close(fig)
-    else:
-        fig.dpi = original_dpi
     return Frame(image)
 
 
-def plots_to_frame(figures, width=512, close_fig=False):
+def plots_to_frame(figures, width=512, close_fig=False, bbox_inches=None):
     """ Renders an iterable of matplotlib figures or axes objects into a
     pims Frame object, that will be displayed as scrollable stack in IPython.
 

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -47,15 +47,24 @@ class TestPlotToFrame(unittest.TestCase):
         frame = plot_to_frame(self.figures[0])
         assert_equal(frame.shape, self.expected_shape[1:])
 
-    def test_change_width(self):
-        width = np.random.randint(100, 1000)
-        frame = plot_to_frame(self.figures[0], width)
-        assert_equal(frame.shape[1], width)
-
     def test_axes_to_frame(self):
         frame = plots_to_frame(self.axes)
         assert_equal(frame.shape, (10, 384, 512, 4))
 
     def test_plots_to_frame(self):
         frame = plots_to_frame(self.figures)
+        assert_equal(frame.shape, (10, 384, 512, 4))
+
+    def test_plot_width(self):
+        width = np.random.randint(100, 1000)
+        frame = plot_to_frame(self.figures[0], width)
+        assert_equal(frame.shape[1], width)
+
+    def test_plots_width(self):
+        width = np.random.randint(100, 1000)
+        frame = plots_to_frame(self.figures, width)
+        assert_equal(frame.shape[2], width)
+
+    def test_plots_from_generator(self):
+        frame = plots_to_frame(iter(self.figures))
         assert_equal(frame.shape, (10, 384, 512, 4))

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -1,0 +1,61 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import six
+import nose
+import numpy as np
+from pims import plot_to_frame, plots_to_frame
+from nose.tools import assert_true, assert_equal
+import unittest
+try:
+    import matplotlib.pyplot as plt
+except ImportError:
+    plt = None
+
+def _skip_if_no_mpl():
+    if plt is None:
+        raise nose.SkipTest('Matplotlib not installed. Skipping.')
+
+class TestPlotToFrame(unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_mpl()
+        plt.switch_backend('Agg')  # does not plot to screen
+        x = np.linspace(0, 2*np.pi, 100)
+        t = np.linspace(0, 2*np.pi, 10)
+        y = np.sin(x[np.newaxis, :] - t[:, np.newaxis])
+
+        self.figures = []
+        self.axes = []
+        for line in y:
+            fig = plt.figure(figsize=(8, 6))
+            ax = fig.gca()
+            ax.plot(x, line)
+            self.figures.append(fig)
+            self.axes.append(ax)
+
+        self.expected_shape = (10, 384, 512, 4)
+
+    def tearDown(self):
+        for fig in self.figures:
+            plt.close(fig)
+
+    def test_ax_to_frame(self):
+        frame = plot_to_frame(self.axes[0])
+        assert_equal(frame.shape, self.expected_shape[1:])
+
+    def test_plot_to_frame(self):
+        frame = plot_to_frame(self.figures[0])
+        assert_equal(frame.shape, self.expected_shape[1:])
+
+    def test_change_width(self):
+        width = np.random.randint(100, 1000)
+        frame = plot_to_frame(self.figures[0], width)
+        assert_equal(frame.shape[1], width)
+
+    def test_axes_to_frame(self):
+        frame = plots_to_frame(self.axes)
+        assert_equal(frame.shape, (10, 384, 512, 4))
+
+    def test_plots_to_frame(self):
+        frame = plots_to_frame(self.figures)
+        assert_equal(frame.shape, (10, 384, 512, 4))

--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -419,22 +419,26 @@ class TiffStack_pil(FramesSequence):
 
     def _read_metadata(self):
         """Read metadata for current frame and return as dict"""
+        try:
+            tags = self.im.tag_v2  # for Pillow >= v3.0.0
+        except AttributeError:
+            tags = self.im.tag  # for Pillow < v3.0.0
         md = {}
         try:
-            md["ImageDescription"] = self.im.tag[270]
-        except:
+            md["ImageDescription"] = tags[270]
+        except KeyError:
             pass
         try:
-            md["DateTime"] = _tiff_datetime(self.im.tag[306])
-        except:
+            md["DateTime"] = _tiff_datetime(tags[306])
+        except KeyError:
             pass
         try:
-            md["Software"] = self.im.tag[305]
-        except:
+            md["Software"] = tags[305]
+        except KeyError:
             pass
         try:
-            md["DocumentName"] = self.im.tag[269]
-        except:
+            md["DocumentName"] = tags[269]
+        except KeyError:
             pass
         return md
 


### PR DESCRIPTION
This circumvents PIL, now there should not be an issue with PIL 3.0.0.

Before, the code used `fig.imsave` to a buffer, now it uses the built in `print_to_buffer` from the `FigureCanvasAgg` backend. I still need to look at how to correctly pass the kwargs that I used to pass into imsave. For instance `bbox_inches='tight'` that trackpy uses in `annotate3d`.