### PR TITLE
DOC Refactor, reduce readme.md contents.

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,23 @@ Scientific video can be packaged in various ways: familiar video formats like
 .AVI and .MOV, folders full of numbered images, or "stacks" of TIFF images. Each
 of these requires a separate Python module. And, once loaded, they have
 different methods for **accessing individual images, looping through the images
-in bulk, or access a specific range**. PIMS can do all of these using a
-consistent interface, handling the differences between different inputs invisibly.
+in bulk, accessing a specific range, or dealing with multidimensional files**.
+PIMS can do all of these using a consistent interface, handling the differences
+between different inputs invisibly.
+
+Formats readable by pims include:
+* Directories or zipfiles of still images (most formats, including TIFF, JPEG, PNG, BMP), and TIFF stacks
+* Microscope images supported by the [Bio-formats project](https://www.openmicroscopy.org/site/support/bio-formats5.1/supported-formats.html), including Leica, Nikon, Olympus, and Zeiss formats. Requires separate installation; see below.
+* Movie formats and codecs supported by ffmpeg, including AVI, QuickTime MOV, and H.264 (MP4). May require separate installation; see below.
+* CINE files from Vision Research cameras
+* SEQ files from NorPix StreamPix software
 
 PIMS is based on readers by:
 * [scikit-image](http://scikit-image.org/)
 * [matplotlib](http://matplotlib.org/)
 * [scipy](http://www.scipy.org/)
 * [ffmpeg](https://www.ffmpeg.org/) and [PyAV](http://mikeboers.github.io/PyAV/) (video formats such as AVI, MOV)
-* [jpype](http://jpype.readthedocs.org/en/latest/) (interface with bioformats to support [many](https://www.openmicroscopy.org/site/support/bio-formats5.1/supported-formats.html) microscopy formats)
+* [jpype](http://jpype.readthedocs.org/en/latest/) (interface with Bio-formats)
 * [Pillow](http://pillow.readthedocs.org/en/latest/) (improved TIFF support)
 * [libtiff](https://code.google.com/p/pylibtiff/) (alternative TIFF support)
 * [tifffile](http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html) (alterative TIFF support)

--- a/README.md
+++ b/README.md
@@ -6,26 +6,17 @@ pims: Python Image Sequence
 What Problem Does PIMS Solve?
 -----------------------------
 
-Scientific video can be packaged in various ways: familiar video formats like .AVI and .MOV, folders full of numbered images, or "stacks" of TIFF images. Each of these requires a separate Python module. And, once loaded, they have different methods for **accessing individual images, looping through the images in bulk, or access a specific range**. PIMS can do all of these using a consistent interface, handling the differences between different inputs invisibly.
+Scientific video can be packaged in various ways: familiar video formats like
+.AVI and .MOV, folders full of numbered images, or "stacks" of TIFF images. Each
+of these requires a separate Python module. And, once loaded, they have
+different methods for **accessing individual images, looping through the images
+in bulk, or access a specific range**. PIMS can do all of these using a
+consistent interface, handling the differences between different inputs invisibly.
 
-Examples & Documentation
-------------------------
-
-Everything is demonstrated in [this IPython notebook](http://nbviewer.ipython.org/github/soft-matter/pims/blob/master/examples/loading%20video%20frames.ipynb).
-
-Dependencies
-------------
-
-PIMS depends on [numpy](http://www.numpy.org) and [slicerator](https://github.com/soft-matter/slicerator).
-
-For basic image reading one of the following is required:
-
+PIMS is based on readers by:
 * [scikit-image](http://scikit-image.org/)
 * [matplotlib](http://matplotlib.org/)
 * [scipy](http://www.scipy.org/)
-
-Depending on what file formats you want to read, you will also need:
-
 * [ffmpeg](https://www.ffmpeg.org/) and [PyAV](http://mikeboers.github.io/PyAV/) (video formats such as AVI, MOV)
 * [jpype](http://jpype.readthedocs.org/en/latest/) (interface with bioformats to support [many](https://www.openmicroscopy.org/site/support/bio-formats5.1/supported-formats.html) microscopy formats)
 * [Pillow](http://pillow.readthedocs.org/en/latest/) (improved TIFF support)
@@ -33,118 +24,10 @@ Depending on what file formats you want to read, you will also need:
 * [tifffile](http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html) (alterative TIFF support)
 * [pims_nd2](https://github.com/soft-matter/pims_nd2) (improved Nikon .nd2 support)
 
-Basic Installation
-------------------
+Examples & Documentation
+------------------------
 
-Installation is simple on Windows, OSX, and Linux, even for Python novices.
+Everything is demonstrated in [this IPython notebook](http://nbviewer.ipython.org/github/soft-matter/pims/blob/master/examples/loading%20video%20frames.ipynb).
 
-To get started with Python on any platform, download and install
-[Anaconda](https://store.continuum.io/cshop/anaconda/). It comes with the
-common scientific Python packages built in.
-
-Open a command prompt. That's "Terminal" on a Mac, and
-"Start > Applications > Command Prompt" on Windows. Type these
-lines:
-
-    conda update conda
-    conda install numpy matplotlib scikit-image pillow
-    conda install pip
-
-Then, to install pims:
-
-    pip install pims
-
-Finally, to try it out, type:
-
-    ipython notebook
-
-Optional Dependencies
----------------------
-
-### Reading Multi-Frame TIFF Stacks
-
-PIMS can read most TIFF files out of the box, so you should try reading
-you files `(open('my_tiff_file.tif')` and revisit this section if you
-encounter an error. Many camera and software manufacturers have their
-own special variants of the TIFF format. Our default reader, built around
-[Christoph Gohlke's tifffile.py](http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html), handles all the formats we have personally enountered. But we have
-alternative TIFF readers built around
-Pillow (see above) and libtiff, which can be installed like so:
-
-    pip install libtiff
-
-### Reading Video Files (AVI, MOV, etc.)
-
-To load video files directly, you need FFmpeg or libav. These can be tricky to
-install, especially on Windows, so we advise less sophisticated users to simply
-work around this requirement by converting their video files to folders full of
-images using a utility like [ImageJ](http://rsb.info.nih.gov/ij/).
-
-But if either FFmpeg or libav is available, PIMS enables fast random access to
-video files. It relies on PyAV, which can be installed like so:
-
-    pip install av
-
-### Reading microscopy files via Bio-Formats
-
-([List of supported formats](https://www.openmicroscopy.org/site/support/bio-formats5.1/supported-formats.html))
-
-Bio-Formats is an open-source java library for reading and writing
-multidimensional image data, especially from microscopy files. To interface
-with the java library, we use [JPype](https://github.com/originell/jpype) which
-allows fast and easy access to all java functions. JRE or JDK are not required.
-Install JPype as follows:
-
-    pip install jpype1
-
-On first use of `pims.Bioformats(filename)`, the required java library
-`loci_tools.jar` will be automatically downloaded from
-[openmicroscopy.org](http://downloads.openmicroscopy.org/bio-formats/).
-
-Troubleshooting
----------------
-
-### PyAv
-
-If you use conda / Anaconda, watch out for an error like:
-
-    version `GLIBC_2.15' not found
-
-This seems to be because [conda includes an old version of a library needed by
-PyAV](github.com/ContinuumIO/anaconda-issues/issues/182). To work around this,
-simply delete anaconda's version of the library:
-
-    rm ~/anaconda/lib/libm.so.6
-
-and/or
-
-    rm ~/anaconda/envs/name_of_your_environment/lib/libm.so.6
-
-which will cause PyAV to use the your operating system's version of the
-library.
-
-Updating Your Installation
---------------------------
-
-The code is under active development. To update to the current development
-version, run this in the command prompt:
-
-    pip install --upgrade http://github.com/soft-matter/pims/zipball/master
-
-Primary Contributors
---------------------
-* Daniel B. Allan
-* Thomas A. Caswell
-* Casper van der Wel
-
-Supporting Grant
-----------------
-
-This package was originally developed and maintained by Daniel Allan,
-as part of his PhD thesis work on microrheology in Robert L. Leheny's
-group at Johns Hopkins University in Baltimore, MD. The work was
-supported by the National Science Foundation under grant number
-CBET-1033985.
-
-
-Dan can be reached at daniel.b.allan@jhu.edu.
+[**Read the documentation**](http://soft-matter.github.io/pims/) for
+installation instructions, examples, and further reference.

--- a/README.md
+++ b/README.md
@@ -31,3 +31,33 @@ Everything is demonstrated in [this IPython notebook](http://nbviewer.ipython.or
 
 [**Read the documentation**](http://soft-matter.github.io/pims/) for
 installation instructions, examples, and further reference.
+
+Core Contributors
+-----------------
+
+  * **Daniel Allan** founding contributor, slicing and iteration logic,
+    basic readers, display tools
+  * **Thomas Caswell** major refactor, abstract base class
+  * **Casper van der Wel** bioformats readers, display tools
+  * **Thomas Dimiduk** filetype-detecting dispatch logic
+
+Support
+-------
+
+This package was developed in part by Daniel Allan, as part of his
+PhD thesis work on microrheology in Robert L. Leheny's group at Johns Hopkins
+University in Baltimore, MD. The work was supported by the National Science Foundation
+under grant number CBET-1033985. Later work was supported by Brookhaven
+National Lab. Dan can be reached at dallan@bnl.gov.
+
+This package was developed in part by Thomas A Caswell as part of his
+PhD thesis work in Sidney R Nagel's and Margaret L Gardel's groups at
+the University of Chicago, Chicago IL.  This work was supported in
+part by NSF Grant DMR-1105145 and NSF-MRSEC DMR-0820054. Later work was
+supported by Brookhaven National Lab. Tom can be
+reached at tcaswell@gmail.com.
+
+This package was developed in part by Casper van der Wel, as part of his
+PhD thesis work in Daniela Kraft's group at the Huygens-Kamerlingh-Onnes laboratory,
+Institute of Physics, Leiden University, The Netherlands. This work was
+supported by the Netherlands Organisation for Scientific Research (NWO/OCW).

--- a/doc/source/bioformats.rst
+++ b/doc/source/bioformats.rst
@@ -7,16 +7,21 @@ file formats used in microscopy.
 
 See the `list of supported formats <https://www.openmicroscopy.org/site/support/bio-formats5.1/supported-formats.html>`_.
 
-Depedencies
------------
-To interface with the java library, we use `JPype <https://github.com/originell/jpype>`_, which allows fast and easy access to all java functions. JRE or JDK are not required.
+Dependencies
+------------
+To interface with the java library, we use
+`JPype <https://github.com/originell/jpype>`_, which allows fast and easy access
+to all java functions. JRE or JDK are not required.
 
-For installation with pip, use
+For installation with pip, type in the following into the terminal:
 
 .. code-block:: bash
 
     pip install jpype1
 
-to install the correct version (0.6.0 or later).
+Or, for windows users,
+download the binary from `Christoph Gohlke's website http://www.lfd.uci.edu/~gohlke/pythonlibs/#jpype`_.
 
-On first use of pims.Bioformats(filename), the required java library :file:`loci_tools.jar` will be automatically downloaded from openmicroscopy.org.
+On first use of pims.Bioformats(filename), the required java library
+:file:`loci_tools.jar` will be automatically downloaded from
+`openmicroscopy.org <http://downloads.openmicroscopy.org/bio-formats/>`__.

--- a/doc/source/bioformats.rst
+++ b/doc/source/bioformats.rst
@@ -1,6 +1,8 @@
 Bioformats
 ==========
 
+.. seealso:: The section :doc:`multidimensional` describes how to deal with multidimensional files.
+
 The ``Bioformats`` reader interfaces with Bio-Formats, an open-source Java
 library for reading and writing multidimensional image data, especially from
 file formats used in microscopy.

--- a/doc/source/image_sequence.rst
+++ b/doc/source/image_sequence.rst
@@ -14,6 +14,14 @@ filenames.
 * the filepath of a zipped archive, such as ``'my_directory/all-images.zip'``
 * a list of filepaths, such as ``['image1.png', 'image2.png']``
 
+ImageSequenceND
+===============
+
+.. seealso:: The section :doc:`multidimensional` describes how to deal with multidimensional files.
+
+This class allows reading of N-dimensional Image Sequences with multiple indices
+in the file name, for instance: ``['image_z00_t00.png', 'image_z01_t00.png']``.
+
 Dependencies
 ------------
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -80,6 +80,7 @@ Contents
    :maxdepth: 1
 
    install
+   release_notes
    opening_files
    slicing
    frame

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -83,6 +83,7 @@ Contents
    opening_files
    slicing
    frame
+   multidimensional
    custom_readers
 
 Built-in Readers

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -11,6 +11,9 @@ Key features:
 Example
 -------
 
+Everything is demonstrated in `this IPython
+notebook <http://nbviewer.ipython.org/github/soft-matter/pims/blob/master/examples/loading%20video%20frames.ipynb>`__.
+
 Load a sequence of images from a directory, where the images are named
 :file:`img-0.png`, :file:`img-1.png`, etc.
 

--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -124,6 +124,6 @@ supported by Brookhaven National Lab. Tom can be
 reached at tcaswell@gmail.com.
 
 This package was developed in part by Casper van der Wel, as part of his
-PhD thesis work in Daniela Kraft’s group at the Huygens-Kamerlingh-Onnes laboratory,
+PhD thesis work in Daniela Kraft's group at the Huygens-Kamerlingh-Onnes laboratory,
 Institute of Physics, Leiden University, The Netherlands. This work was
-supported by the Netherlands Organisation for Scientific Research (NWO/OCW). 
+supported by the Netherlands Organisation for Scientific Research (NWO/OCW).

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -1,6 +1,8 @@
 Installation
 ============
 
+.. seealso:: What has been changed recently? Check out the :doc:`release_notes`.
+
 PIMS is easy to install on Windows, OSX, or Linux. Its dependencies are:
 
 * `numpy <http://www.numpy.org/>`_

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -12,10 +12,26 @@ For basic image reading one of the following is required:
 * `matplotlib <http://matplotlib.org/>`_
 * `scipy <http://www.scipy.org/>`_
 
+Depending on what file formats you want to read, you will also need:
 
-Recommended: conda 
+-  `ffmpeg <https://www.ffmpeg.org/>`__ and
+   `PyAV <http://mikeboers.github.io/PyAV/>`__ (video formats such as
+   AVI, MOV)
+-  `jpype <http://jpype.readthedocs.org/en/latest/>`__ (interface with
+   bioformats to support
+   `many <https://www.openmicroscopy.org/site/support/bio-formats5.1/supported-formats.html>`__
+   microscopy formats)
+-  `Pillow <http://pillow.readthedocs.org/en/latest/>`__ (improved TIFF
+   support)
+-  `libtiff <https://code.google.com/p/pylibtiff/>`__ (alternative TIFF
+   support)
+-  `tifffile <http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html>`__
+   (alterative TIFF support)
+-  `pims\_nd2 <https://github.com/soft-matter/pims_nd2>`__ (improved
+   Nikon .nd2 support)
+
+Recommended: conda
 ------------------
-
 
 .. note::
 
@@ -25,14 +41,24 @@ Recommended: conda
 
 With `Anaconda <https://store.continuum.io/cshop/anaconda/>`_ 
 (or `Miniconda <http://conda.pydata.org/miniconda.html>`_) installed,
-type the following into a Terminal to install PIMS.
+type the following into a Terminal to install PIMS. That's "Terminal" on a Mac,
+and "Start > Applications > Command Prompt" on Windows. Type these lines:
 
 .. code-block:: bash
 
    conda install -c soft-matter pims
 
-The above installs the latest stable to release. To install the version under
-active development, with the latest tested code, use the development channel.
+The above installs the latest stable release. Finally, to try it out, type:
+
+.. code-block:: bash
+
+    ipython notebook
+
+
+Development version
+-------------------
+To install the version under active development, with the latest tested code,
+use the development channel.
 
 .. code-block:: bash
 
@@ -59,4 +85,3 @@ If you plan to edit the code, you can install PIMS manually.
    git clone https://github.com/soft-matter/pims
    cd pims
    python setup.py develop
-

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -1,0 +1,49 @@
+Release notes
+=============
+
+v0.3.3
+------
+- Fix compatibility with Pillow v0.3.0 (PR 204)
+- API: ``plot_to_frame`` and ``plots_to_frame`` now take ``fig_size_inches`` and
+``bbox_inches`` as keyword arguments instead of passing on all keyword arguments
+to ``imsave`` (PR 206)
+- Fix zipfile handling in Py3 (PR 199)
+- Fix CINE reader for Py2 (PR 219)
+- Update documentation
+- Updated slicerator dependency to v0.9.7 (fixes pipeline nesting)
+
+v0.3.2
+------
+- Bug fixes
+- Build fixes and fewer required deps
+
+v0.3.1
+------
+- Fix build-related mistakes in v0.3.0.
+
+v0.3.0
+------
+
+* Refactor the slicing logic into a separate package, slicerator.
+* Extend the slicing logic to allow nested lazy slicing.
+* Add pipeline feature; deprecate process_func.
+* Support multispectral and multidimensional images.
+* Add Norpix reader.
+
+v0.2.2
+------
+This is a simple maintenance release, introducing no functionality changes. The
+packaging and installation are simplified by adopting tifffile as a dependency
+rather than directly including the source PIMS.
+
+Henceforth, to install PIMS on any platform, we recommend
+``conda install -c soft-matter pims``, but ``pip install pims`` is also supported.
+
+v0.2.1
+------
+
+* Use PyAV for handling video files
+* Ships with Christoph Gohlke's tifffile
+* Added support for .cine files
+* Added prototype of universal open function which tries to guess the correct class to use to handle a given file based on the extension
+* Added ability to create an ImageSequence from a list of paths

--- a/doc/source/tiff_stack.rst
+++ b/doc/source/tiff_stack.rst
@@ -1,6 +1,10 @@
 TiffStack
 =========
 
+PIMS can read most TIFF files out of the box, so you should try reading
+you files ``(open('my_tiff_file.tif')`` and revisit this section if you
+encounter an error.
+
 A tiff stack is a single file (.tif or .tiff) containing several images,
 often a time series or "Z stack."
 
@@ -11,8 +15,11 @@ single-image tiff files (e.g., :file:`img-1.tif`, :file:`img-2.tif`) see
 Dependencies
 -----------
 
-There are several Python packages for reading TIFFs. One may work better than
-others for your application. To use a specific reader, use
+There are several Python packages for reading TIFFs. Our default reader, built
+around `Christoph Gohlke's tifffile.py <http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html>`__,
+handles all the formats we have personally encountered. But we have
+alternative TIFF readers built around Pillow (see above) and libtiff.
+To use a specific reader, use
 ``TiffStack_tifffile``, ``TiffStack_libtiff``, or ``TiffStack_pil``, which
 depend, respectively, on the packages below. The "default" reader,
 ``TiffStack`` is an alias. At import time, it is pointed to the first

--- a/doc/source/video.rst
+++ b/doc/source/video.rst
@@ -3,9 +3,18 @@ Video
 
 .. note::
 
-   To load video files directly, you need FFmpeg or libav. These can be tricky to install, especially on Windows, so we advise less sophisticated users to simply work around this requirement by converting their video files to folders full of images using a utility like `ImageJ <http://rsb.info.nih.gov/ij/>`_.
+   To load video files directly, you need FFmpeg or libav. These can be tricky
+   to install, especially on Windows, so we advise less sophisticated users to
+   simply work around this requirement by converting their video files to
+   folders full of images using a utility like `ImageJ <http://rsb.info.nih.gov/ij/>`_.
 
-   But if either FFmpeg or libav is available, PIMS enables fast random access to video files. 
+   But if either FFmpeg or libav is available, PIMS enables fast random access to video files.
+
+PyAV is installed with the PIMS conda package. You can install it via pip like so:
+
+.. code-block:: bash
+
+    pip install av
 
 The ``Video`` reader can open any file format supported by FFmepg and libav.
 
@@ -19,4 +28,28 @@ Dependencies
 
 * `PyAV <http://mikeboers.github.io/PyAV/>`_
 
-PyAV is installed with the PIMS conda package.
+Troubleshooting
+---------------
+
+If you use conda / Anaconda, watch out for an error like:
+
+.. code-block:: bash
+
+    version `GLIBC_2.15' not found
+
+This seems to be because `conda includes an old version of a library
+needed by PyAV <github.com/ContinuumIO/anaconda-issues/issues/182>`__.
+To work around this, simply delete anaconda's version of the library:
+
+.. code-block:: bash
+
+    rm ~/anaconda/lib/libm.so.6
+
+and/or
+
+.. code-block:: bash
+
+    rm ~/anaconda/envs/name_of_your_environment/lib/libm.so.6
+
+which will cause PyAV to use the your operating system's version of the
+library.


### PR DESCRIPTION
As described in #208, this spread the contents of `readme.md` into the real documentation, and adds a reference to that in the `readme.md`.

Please review the PyAv part carefully, I am not sure if that is entirely correct. I haven't built the documents so it might need some debugging.