### PR TITLE
Try 2 on pull request for Support for non-monochrome and packed-bits images in NorpixSeq,

### DIFF
--- a/pims/norpix_reader.py
+++ b/pims/norpix_reader.py
@@ -135,7 +135,7 @@ class NorpixSeq(FramesSequence):
             self._dtype_native = 'uint8'
         else:
             try:
-        self._pixel_count = self._width * self._height
+                self._pixel_count = self._width * self._height
                 dtype_native = 'uint%i' % self.header_dict['bit_depth']
                 self._dtype_native = np.dtype(dtype_native)
                 self._shape = (self._height, self._width)


### PR DESCRIPTION
but only with the as_raw flag to return a uint8 array.
The user must interpret the raw image correctly, based on the
image_format header entry to determine how to convert
pixel values to RGB, etc.

set_process_func() exposes _validate_process_func() so the user
may open the sequence, examine the header, and then install the process_fun.

This replaces pull-request #216