### PR TITLE
Update bioformats version to 5.1.7

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -10,7 +10,8 @@ to ``imsave`` (PR 206)
 - Fix zipfile handling in Py3 (PR 199)
 - Fix CINE reader for Py2 (PR 219)
 - Update documentation
-- Updated slicerator dependency to v0.9.7 (fixes pipeline nesting)
+- Update slicerator dependency to v0.9.7 (fixes pipeline nesting)
+- Update bioformats version to v5.1.7 (PR 224)
 
 v0.3.2
 ------

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -68,7 +68,7 @@ def _find_jar(url=None):
 
     from six.moves.urllib.request import urlretrieve
     if url is None:
-        url = ('http://downloads.openmicroscopy.org/bio-formats/5.1.2/' +
+        url = ('http://downloads.openmicroscopy.org/bio-formats/5.1.7/' +
                'artifacts/loci_tools.jar')
     urlretrieve(url, os.path.join(loc, 'loci_tools.jar'))
 

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -383,8 +383,8 @@ class BioformatsReader(FramesSequenceND):
             if isinstance(Jarr[:], np.ndarray):
                 read_mode = 'jpype'
             else:
-                warn('JPype numpy conversion is not installed properly. '
-                     'Falling back to slower read modes.')
+                warn('Due to an issue with JPype 0.6.0, reading is slower. '
+                     'Please consider upgrading JPype to 0.6.1 or later.')
                 try:
                     im = self._jbytearr_stringbuffer(Jarr)
                     im.reshape(self._sizeRGB, self._sizeX, self._sizeY)


### PR DESCRIPTION
Travis couldn't download loci_tools.jar. The URL was still right, probably a temporary error. But it made me update bioformats. All tests pass locally.

It will probably fix the travis build when merged.