### PR TITLE
Expose the metadata attribute names

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,9 @@ sudo: false
 matrix:
   include:
     - python: "2.7"
-      env: DEPS="numpy=1.9*" DEPSSM="tifffile"
+      env: DEPS="nomkl numpy=1.9*" DEPSSM="tifffile"
     - python: "2.7"
-      env: DEPS="numpy=1.9* scipy pillow matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
+      env: DEPS="nomkl numpy=1.9* scipy pillow matplotlib scikit-image jinja2" DEPSSM="pyav tifffile"
     - python: "3.4"
       env: DEPS="numpy=1.9*" DEPSSM="tifffile"
     - python: "3.4"

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -150,6 +150,8 @@ class MetadataRetrieve(object):
                 except ValueError:
                     return field
 
+        self.fields = []
+
         for name in dir(md):
             if (name[:3] != 'get') or (name in ['getRoot', 'getClass']):
                 continue
@@ -168,12 +170,11 @@ class MetadataRetrieve(object):
                                    name + ' wrapped\nby JPype and an '
                                    'additional automatic typeconversion.\n\n')
                     setattr(self, name[3:], fnw)
+                    self.fields.append(name[3:])
                     continue
                 except:
                     # function is not supported by this specific reader
                     pass
-
-        self.fields = list(filter(lambda x: x[:2] != '__', dir(self)))
 
     def __repr__(self):
         return '<MetadataRetrieve> Available loci.formats.meta.' + \

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -173,10 +173,11 @@ class MetadataRetrieve(object):
                     # function is not supported by this specific reader
                     pass
 
+        self.fields = list(filter(lambda x: x[:2] != '__', dir(self)))
+
     def __repr__(self):
-        listing = list(filter(lambda x: x[:2] != '__', dir(self)))
         return '<MetadataRetrieve> Available loci.formats.meta.' + \
-               'MetadataRetrieve functions: ' + ', '.join(listing)
+               'MetadataRetrieve functions: ' + ', '.join(self.fields)
 
 
 class BioformatsReader(FramesSequenceND):

--- a/pims/tests/test_bioformats.py
+++ b/pims/tests/test_bioformats.py
@@ -544,34 +544,7 @@ class TestBioformatsMetadataND2(unittest.TestCase):
     def test_metadata_tags(self):
         self.v = self.klass(self.filename, meta=True)
         fields = self.v.metadata.fields
-        expected_fields = {
-            'ChannelAnnotationRefCount', 'ChannelColor', 'ChannelCount',
-            'ChannelEmissionWavelength', 'ChannelID', 'ChannelName',
-            'ChannelSamplesPerPixel', 'DatasetCount',
-            'DetectorAnnotationRefCount', 'DetectorCount', 'DetectorID',
-            'DetectorModel', 'DetectorSettingsID', 'DetectorType',
-            'DichroicCount', 'ExperimentCount', 'ExperimenterCount',
-            'ExperimenterGroupCount', 'FilterCount', 'FilterSetCount',
-            'ImageAnnotationRefCount', 'ImageCount', 'ImageID',
-            'ImageInstrumentRef', 'ImageName', 'ImageROIRefCount',
-            'InstrumentAnnotationRefCount', 'InstrumentCount', 'InstrumentID',
-            'LightPathAnnotationRefCount', 'LightPathEmissionFilterRefCount',
-            'LightPathExcitationFilterRefCount', 'LightSourceCount',
-            'MicrobeamManipulationRefCount', 'ObjectiveAnnotationRefCount',
-            'ObjectiveCorrection', 'ObjectiveCount', 'ObjectiveID',
-            'ObjectiveImmersion', 'ObjectiveSettingsID',
-            'ObjectiveSettingsRefractiveIndex', 'PixelsBigEndian',
-            'PixelsBinDataBigEndian', 'PixelsBinDataCount',
-            'PixelsDimensionOrder', 'PixelsID', 'PixelsInterleaved',
-            'PixelsPhysicalSizeX', 'PixelsPhysicalSizeY',
-            'PixelsPhysicalSizeZ', 'PixelsSignificantBits', 'PixelsSizeC',
-            'PixelsSizeT', 'PixelsSizeX', 'PixelsSizeY', 'PixelsSizeZ',
-            'PixelsType', 'PlaneAnnotationRefCount', 'PlaneCount',
-            'PlaneDeltaT', 'PlaneExposureTime', 'PlanePositionX',
-            'PlanePositionY', 'PlanePositionZ', 'PlaneTheC', 'PlaneTheT',
-            'PlaneTheZ', 'PlateCount', 'ProjectCount', 'ROICount',
-            'ScreenCount', 'TiffDataCount'}
-        assert_equal(set(fields), expected_fields)
+        assert 'PixelsPhysicalSizeX' in fields
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs'],

--- a/pims/tests/test_bioformats.py
+++ b/pims/tests/test_bioformats.py
@@ -541,6 +541,37 @@ class TestBioformatsMetadataND2(unittest.TestCase):
         assert_equal(metadata['CH2ChannelDyeName'], '5-FAM/pH 9.0')
         assert_equal(metadata['dCalibration'], '0.16780898323268245')
 
+    def test_metadata_tags(self):
+        self.v = self.klass(self.filename, meta=True)
+        fields = self.v.metadata.fields
+        expected_fields = {
+            'ChannelAnnotationRefCount', 'ChannelColor', 'ChannelCount',
+            'ChannelEmissionWavelength', 'ChannelID', 'ChannelName',
+            'ChannelSamplesPerPixel', 'DatasetCount',
+            'DetectorAnnotationRefCount', 'DetectorCount', 'DetectorID',
+            'DetectorModel', 'DetectorSettingsID', 'DetectorType',
+            'DichroicCount', 'ExperimentCount', 'ExperimenterCount',
+            'ExperimenterGroupCount', 'FilterCount', 'FilterSetCount',
+            'ImageAnnotationRefCount', 'ImageCount', 'ImageID',
+            'ImageInstrumentRef', 'ImageName', 'ImageROIRefCount',
+            'InstrumentAnnotationRefCount', 'InstrumentCount', 'InstrumentID',
+            'LightPathAnnotationRefCount', 'LightPathEmissionFilterRefCount',
+            'LightPathExcitationFilterRefCount', 'LightSourceCount',
+            'MicrobeamManipulationRefCount', 'ObjectiveAnnotationRefCount',
+            'ObjectiveCorrection', 'ObjectiveCount', 'ObjectiveID',
+            'ObjectiveImmersion', 'ObjectiveSettingsID',
+            'ObjectiveSettingsRefractiveIndex', 'PixelsBigEndian',
+            'PixelsBinDataBigEndian', 'PixelsBinDataCount',
+            'PixelsDimensionOrder', 'PixelsID', 'PixelsInterleaved',
+            'PixelsPhysicalSizeX', 'PixelsPhysicalSizeY',
+            'PixelsPhysicalSizeZ', 'PixelsSignificantBits', 'PixelsSizeC',
+            'PixelsSizeT', 'PixelsSizeX', 'PixelsSizeY', 'PixelsSizeZ',
+            'PixelsType', 'PlaneAnnotationRefCount', 'PlaneCount',
+            'PlaneDeltaT', 'PlaneExposureTime', 'PlanePositionX',
+            'PlanePositionY', 'PlanePositionZ', 'PlaneTheC', 'PlaneTheT',
+            'PlaneTheZ', 'PlateCount', 'ProjectCount', 'ROICount',
+            'ScreenCount', 'TiffDataCount'}
+        assert_equal(set(fields), expected_fields)
 
 if __name__ == '__main__':
     nose.runmodule(argv=[__file__, '-vvs'],


### PR DESCRIPTION
As requested in #229, add an attribute to MetadataRetrieve to programmatically list the available field names. The accessible fields were calculated during the call to repr, so I just moved that calculation to the bottom of init and assigned it to `self.fields`. Let me know what you'd prefer it to be called.

I added a test that verifies all the expected fields that appear on one of the test images. There's a lot of attributes, so let me know if there's a better image to work with, or if there's a better test than exhaustively listing them all out. Frankly, I only care about a few of the fields, but I guess it's nice to know that they're all there if you need them?