### PR TITLE
spe_stack: Make `frame_shape` match frames' `shape`

### DIFF
--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -1,6 +1,11 @@
 Release notes
 =============
 
+v0.3.4
+------
+- API: Swap elements of ``frame_shape`` in ``SpeStack`` to match frames'
+  ``shape``.
+
 v0.3.3
 ------
 - Fix compatibility with Pillow v0.3.0 (PR 204)

--- a/pims/spe_stack.py
+++ b/pims/spe_stack.py
@@ -233,7 +233,7 @@ class SpeStack(FramesSequence):
 
     @property
     def frame_shape(self):
-        return self._width, self._height
+        return self._height, self._width
 
     def __len__(self):
         return self._len


### PR DESCRIPTION
`frame_shape` used to be (width, height), while the individual frames'
`shapes` are (row count, column count), i. e. the other way round.