### PR TITLE
FIX Plot_to_frame with safefig.bbox == 'tight'

### DIFF
--- a/pims/display.py
+++ b/pims/display.py
@@ -615,11 +615,10 @@ def plot_to_frame(fig, width=512, close_fig=False, fig_size_inches=None,
     with _fig_size_cntx(fig, fig_size_inches, tight_layout) as fig:
         width_in, height_in = fig.get_size_inches()
         dpi = width / width_in
-        buf_shape = (int(height_in * dpi), int(width_in * dpi), 4)
-        fig.savefig(buf, format='rgba', dpi=dpi)
+        fig.savefig(buf, format='png', dpi=dpi)
 
     buf.seek(0)
-    image = np.fromstring(buf.read(), dtype='uint8').reshape(*buf_shape)
+    image = plt.imread(buf)
     if close_fig:
         plt.close(fig)
     return Frame(image)

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -5,7 +5,7 @@ import six
 import nose
 import numpy as np
 from pims import plot_to_frame, plots_to_frame
-from nose.tools import assert_true, assert_equal
+from nose.tools import assert_true, assert_equal, assert_less
 import unittest
 try:
     import matplotlib as mpl
@@ -29,7 +29,7 @@ class TestPlotToFrame(unittest.TestCase):
         self.figures = []
         self.axes = []
         for line in y:
-            fig = plt.figure(figsize=(8, 6))
+            fig = plt.figure(figsize=(8, 6), tight_layout=False)
             ax = fig.gca()
             ax.plot(x, line)
             self.figures.append(fig)
@@ -65,12 +65,21 @@ class TestPlotToFrame(unittest.TestCase):
         assert_equal(frame.shape[1], width)
 
     def test_plot_tight(self):
-        frame = plot_to_frame(self.figures[0], bbox_inches='tight')
-        assert_equal(frame.shape, (384, 512, 4))
+        fig = self.figures[0]
+        fig.set_tight_layout(False)  # default to standard
+        assert_equal(plot_to_frame(fig).shape[:2], (384, 512))
+        assert_less(plot_to_frame(fig, bbox_inches='tight').shape[:2], (384, 512))
+        assert_equal(plot_to_frame(fig).shape[:2], (384, 512))
+
+        fig.set_tight_layout(True)   # default to tight
+        assert_less(plot_to_frame(fig).shape[:2], (384, 512))
+        assert_equal(plot_to_frame(fig, bbox_inches='standard').shape[:2],
+                    (384, 512))
+        assert_less(plot_to_frame(fig).shape[:2], (384, 512))
 
     def test_plots_tight(self):
         frame = plots_to_frame(self.figures, bbox_inches='tight')
-        assert_equal(frame.shape, (10, 384, 512, 4))
+        assert_less(frame.shape[1:3], (384, 512))
 
     def test_plot_resize(self):
         frame = plot_to_frame(self.figures[0], fig_size_inches=(4, 4))

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -97,9 +97,3 @@ class TestPlotToFrame(unittest.TestCase):
     def test_plots_from_generator(self):
         frame = plots_to_frame(iter(self.figures))
         assert_equal(frame.shape, (10, 384, 512, 4))
-
-    def test_plot_tightrc(self):
-        mpl.rcParams.update({'savefig.bbox': 'tight'})
-        # this makes the image smaller than expected from figsize and dpi
-        frame = plot_to_frame(self.figures[0])
-

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -8,8 +8,10 @@ from pims import plot_to_frame, plots_to_frame
 from nose.tools import assert_true, assert_equal
 import unittest
 try:
+    import matplotlib as mpl
     import matplotlib.pyplot as plt
 except ImportError:
+    mpl = None
     plt = None
 
 def _skip_if_no_mpl():
@@ -34,6 +36,8 @@ class TestPlotToFrame(unittest.TestCase):
             self.axes.append(ax)
 
         self.expected_shape = (10, 384, 512, 4)
+
+        mpl.rcParams.update({'savefig.bbox': None})
 
     def tearDown(self):
         for fig in self.figures:
@@ -84,3 +88,9 @@ class TestPlotToFrame(unittest.TestCase):
     def test_plots_from_generator(self):
         frame = plots_to_frame(iter(self.figures))
         assert_equal(frame.shape, (10, 384, 512, 4))
+
+    def test_plot_tightrc(self):
+        mpl.rcParams.update({'savefig.bbox': 'tight'})
+        # this makes the image smaller than expected from figsize and dpi
+        frame = plot_to_frame(self.figures[0])
+


### PR DESCRIPTION
This solves issue #244 
There is some performance degrade by going via PNG instead of a raw RGBA array, but it certaintly makes this conversion more robust. 