### PR TITLE
ENH Sequence of ND Readers, Single image reader

### DIFF
--- a/pims/api.py
+++ b/pims/api.py
@@ -15,6 +15,7 @@ from warnings import warn
 
 # has to be here for API stuff
 from pims.image_sequence import ImageSequence, ImageSequenceND, ReaderSequence  # noqa
+from pims.image_reader import ImageReader, ImageReaderND  # noqa
 from .cine import Cine  # noqa
 from .norpix_reader import NorpixSeq  # noqa
 from pims.tiff_stack import TiffStack_tifffile  # noqa

--- a/pims/api.py
+++ b/pims/api.py
@@ -14,7 +14,7 @@ import os
 from warnings import warn
 
 # has to be here for API stuff
-from pims.image_sequence import ImageSequence, ImageSequenceND  # noqa
+from pims.image_sequence import ImageSequence, ImageSequenceND, ReaderSequence  # noqa
 from .cine import Cine  # noqa
 from .norpix_reader import NorpixSeq  # noqa
 from pims.tiff_stack import TiffStack_tifffile  # noqa

--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -416,13 +416,13 @@ def _make_get_frame(result_axes, get_frame_dict, sizes, dtype):
 
 class DefaultCoordsDict(dict):
     """Dictionary that checks whether all keys are in `axes`"""
-    def __init__(self, reader, *args, **kwargs):
+    def __init__(self, default_coords=None):
         """There is no check done here"""
-        super(DefaultCoordsDict, self).__init__(*args, **kwargs)
-        self._reader = reader
+        super(DefaultCoordsDict, self).__init__()
+        self.axes = []
 
     def __setitem__(self, attr, value):
-        if attr not in self._reader.sizes:
+        if attr not in self.axes:
             raise ValueError("axes %r does not exist" % attr)
         super(DefaultCoordsDict, self).__setitem__(attr, value)
 
@@ -512,7 +512,7 @@ class FramesSequenceND(FramesSequence):
 
     def _clear_axes(self):
         self._sizes = {}
-        self._default_coords = DefaultCoordsDict(self, {})
+        self._default_coords = DefaultCoordsDict()
         self._iter_axes = []
         self._bundle_axes = ['y', 'x']
         self._get_frame_wrapped = None
@@ -527,6 +527,7 @@ class FramesSequenceND(FramesSequence):
         if name in self._sizes:
             raise ValueError("axis '{}' already exists".format(name))
         self._sizes[name] = int(size)
+        self.default_coords.axes = self.axes
         self.default_coords[name] = int(default)
 
     def __len__(self):

--- a/pims/image_reader.py
+++ b/pims/image_reader.py
@@ -1,0 +1,101 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import numpy as np
+
+from pims.base_frames import FramesSequence, FramesSequenceND
+from pims.frame import Frame
+
+# skimage.io.plugin_order() gives a nice hierarchy of implementations of imread.
+# If skimage is not available, go down our own hard-coded hierarchy.
+try:
+    from skimage.io import imread
+except ImportError:
+    try:
+        from matplotlib.pyplot import imread
+    except ImportError:
+        try:
+            from scipy.ndimage import imread
+        except:
+            imread = None
+
+
+class ImageReader(FramesSequence):
+    """Reads a single image into a length-1 reader.
+
+    Simple wrapper around skimage.io.imread or matplotlib.pyplot.imread or
+    scipy.ndimage.imread, in that priority order."""
+    @classmethod
+    def class_exts(cls):
+        return {'png', 'jpg', 'jpeg', 'gif', 'bmp', 'ico'}
+
+    class_priority = 12
+
+    def __init__(self, filename, **kwargs):
+        if imread is None:
+            raise ImportError("One of the following packages are required for "
+                              "using the ImageReader: "
+                              "scipy, matplotlib or scikit-image.")
+
+        self._data = imread(filename, **kwargs)
+
+    def get_frame(self, i):
+        return Frame(self._data, frame_no=0)
+
+    def __len__(self):
+        return 1
+
+    @property
+    def pixel_type(self):
+        return self._data.dtype
+
+    @property
+    def frame_shape(self):
+        return self._data.shape
+
+
+class ImageReaderND(FramesSequenceND):
+    """Reads a single image into a dimension-aware reader.
+
+    Simple wrapper around skimage.io.imread or matplotlib.pyplot.imread or
+    scipy.ndimage.imread, in that priority order."""
+    @classmethod
+    def class_exts(cls):
+        return {'png', 'jpg', 'jpeg', 'gif', 'bmp', 'ico'}
+
+    class_priority = 11
+
+    def __init__(self, filename, **kwargs):
+        if imread is None:
+            raise ImportError("One of the following packages are required for "
+                              "using the ImageReaderND: "
+                              "scipy, matplotlib or scikit-image.")
+        super(ImageReaderND, self).__init__()
+
+        self._data = Frame(imread(filename, **kwargs), frame_no=0)
+        shape = self._data.shape
+        if len(shape) == 2:   # greyscale
+            self._init_axis('y', shape[0])
+            self._init_axis('x', shape[1])
+            self._register_get_frame(self.get_frame_2D, 'yx')
+            self.bundle_axes = 'yx'
+        elif (len(shape) == 3) and (shape[2] in (3, 4)):   # grayscale
+            self._init_axis('y', shape[0])
+            self._init_axis('x', shape[1])
+            self._init_axis('c', shape[2])
+            self._register_get_frame(self.get_frame_2D, 'yxc')
+            self.bundle_axes = 'yxc'
+        else:
+            raise IOError('The image has a shape that is not grayscale nor RGB:'
+                          ' {}'.format(shape))
+
+    def get_frame_2D(self, **ind):
+        return Frame(self._data, frame_no=0)
+
+    @property
+    def pixel_type(self):
+        return self._data.dtype
+
+    @property
+    def frame_shape(self):
+        return self._data.shape

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -422,6 +422,51 @@ class _image_rgb(_image_single):
         self.assertEqual(ndim, 2)
 
 
+class TestImageReaderTIFF(_image_single, unittest.TestCase):
+    def check_skip(self):
+        _skip_if_no_PIL()
+
+    def setUp(self):
+        self.filename = os.path.join(path, 'stuck.tif')
+        self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
+        self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
+        self.klass = pims.ImageReader
+        self.kwargs = dict()
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = (5, 512, 512)
+        self.expected_len = 1
+
+
+class TestImageReaderPNG(_image_single, unittest.TestCase):
+    def check_skip(self):
+        _skip_if_no_PIL()
+
+    def setUp(self):
+        self.klass = pims.ImageReader
+        self.kwargs = dict()
+        self.expected_shape = (10, 11)
+        self.expected_len = 1
+
+        save_dummy_png(path, ['dummy.png'], self.expected_shape)
+        self.v = self.klass(os.path.join(path, 'dummy.png'), **self.kwargs)
+        clean_dummy_png(path, ['dummy.png'])
+
+
+class TestImageReaderND(_image_single, unittest.TestCase):
+    def check_skip(self):
+        _skip_if_no_PIL()
+
+    def setUp(self):
+        self.klass = pims.ImageReaderND
+        self.kwargs = dict()
+        self.expected_shape = (10, 11, 3)
+        self.expected_len = 1
+
+        save_dummy_png(path, ['dummy.png'], self.expected_shape)
+        self.v = self.klass(os.path.join(path, 'dummy.png'), **self.kwargs)
+        clean_dummy_png(path, ['dummy.png'])
+
+
 class TestVideo_PyAV(_image_series, _image_rgb, _deprecated_functions,
                      unittest.TestCase):
     def check_skip(self):
@@ -572,6 +617,13 @@ class TestSpeStack(_image_series, _deprecated_functions,
 class TestOpenFiles(unittest.TestCase):
     def setUp(self):
         _skip_if_no_PIL()
+
+    def test_open_png(self):
+        self.filenames = ['dummy_png.png']
+        shape = (10, 11)
+        save_dummy_png(path, self.filenames, shape)
+        pims.open(os.path.join(path, 'dummy_png.png'))
+        clean_dummy_png(path, self.filenames)
 
     def test_open_pngs(self):
         self.filepath = os.path.join(path, 'image_sequence')

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -423,10 +423,8 @@ class _image_rgb(_image_single):
 
 
 class TestImageReaderTIFF(_image_single, unittest.TestCase):
-    def check_skip(self):
-        _skip_if_no_PIL()
-
     def setUp(self):
+        _skip_if_no_imread()
         self.filename = os.path.join(path, 'stuck.tif')
         self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
         self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
@@ -438,10 +436,8 @@ class TestImageReaderTIFF(_image_single, unittest.TestCase):
 
 
 class TestImageReaderPNG(_image_single, unittest.TestCase):
-    def check_skip(self):
-        _skip_if_no_PIL()
-
     def setUp(self):
+        _skip_if_no_imread()
         self.klass = pims.ImageReader
         self.kwargs = dict()
         self.expected_shape = (10, 11)
@@ -453,10 +449,8 @@ class TestImageReaderPNG(_image_single, unittest.TestCase):
 
 
 class TestImageReaderND(_image_single, unittest.TestCase):
-    def check_skip(self):
-        _skip_if_no_PIL()
-
     def setUp(self):
+        _skip_if_no_imread()
         self.klass = pims.ImageReaderND
         self.kwargs = dict()
         self.expected_shape = (10, 11, 3)

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -4,14 +4,11 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import os
-import tempfile
-import zipfile
 import sys
 import random
 import types
 import unittest
 import pickle
-from io import BytesIO
 import nose
 import numpy as np
 from numpy.testing import (assert_equal, assert_allclose)
@@ -238,7 +235,7 @@ class TestRecursiveSlicing(unittest.TestCase):
         compare_slice_to_list(slice2b, list('jihgfed'))
         slice2c = slice1a[::-2]
         compare_slice_to_list(slice2c, list('jhfd'))
-        print('slice2d')
+        # print('slice2d')
         slice2d = slice1a[:0:-1]
         compare_slice_to_list(slice2d, list('jihgfe'))
         slice2e = slice1a[-1:1:-1]
@@ -279,13 +276,13 @@ class TestRecursiveSlicing(unittest.TestCase):
         compare_slice_to_list(slice2, list('cegi'))
         slice3 = slice2[:]
         compare_slice_to_list(slice3, list('cegi'))
-        print('define slice4')
+        # print('define slice4')
         slice4 = slice3[:-1]
-        print('compare slice4')
+        # print('compare slice4')
         compare_slice_to_list(slice4, list('ceg'))
-        print('define slice4a')
+        # print('define slice4a')
         slice4a = slice3[::-1]
-        print('compare slice4a')
+        # print('compare slice4a')
         compare_slice_to_list(slice4a, list('igec'))
 
     def test_slice_with_generator(self):
@@ -296,7 +293,7 @@ class TestRecursiveSlicing(unittest.TestCase):
         assert_true(isinstance(slice2, types.GeneratorType))
 
 def _rescale(img):
-    print(type(img))
+    # print(type(img))
     return (img - img.min()) / img.ptp()
 
 def _color_channel(img, channel):
@@ -509,131 +506,6 @@ class TestTiffStack_libtiff(_tiff_image_series, _deprecated_functions,
         self.expected_len = 5
 
 
-class TestImageSequenceWithPIL(_image_series, _deprecated_functions,
-                               unittest.TestCase):
-    def setUp(self):
-        _skip_if_no_skimage()
-        self.filepath = os.path.join(path, 'image_sequence')
-        self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
-                          'T76S3F00003.png', 'T76S3F00004.png',
-                          'T76S3F00005.png']
-        shape = (10, 11)
-        frames = save_dummy_png(self.filepath, self.filenames, shape)
-
-        self.filename = os.path.join(self.filepath, '*.png')
-        self.frame0 = frames[0]
-        self.frame1 = frames[1]
-        self.kwargs = dict(plugin='pil')
-        self.klass = pims.ImageSequence
-        self.v = self.klass(self.filename, **self.kwargs)
-        self.expected_shape = shape
-        self.expected_len = 5
-        self.tempdir = tempfile.mkdtemp()
-        self.tempfile = os.path.join(self.tempdir, 'test.zip')
-
-        with zipfile.ZipFile(self.tempfile, 'w') as archive:
-            for fn in self.filenames:
-                archive.write(os.path.join(self.filepath, fn))
-
-    def test_bad_path_raises(self):
-        raises = lambda: pims.ImageSequence('this/path/does/not/exist/*.jpg')
-        self.assertRaises(IOError, raises)
-
-    def test_zipfile(self):
-        pims.ImageSequence(self.tempfile)[0]
-
-    def tearDown(self):
-        clean_dummy_png(self.filepath, self.filenames)
-        os.remove(self.tempfile)
-        os.rmdir(self.tempdir)
-
-
-class TestImageSequenceWithMPL(_image_series, _deprecated_functions,
-                               unittest.TestCase):
-    def setUp(self):
-        _skip_if_no_skimage()
-        self.filepath = os.path.join(path, 'image_sequence')
-        self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
-                          'T76S3F00003.png', 'T76S3F00004.png',
-                          'T76S3F00005.png']
-        shape = (10, 11)
-        frames = save_dummy_png(self.filepath, self.filenames, shape)
-        self.filename = os.path.join(self.filepath, '*.png')
-        self.frame0 = frames[0]
-        self.frame1 = frames[1]
-        self.kwargs = dict(plugin='matplotlib')
-        self.klass = pims.ImageSequence
-        self.v = self.klass(self.filename, **self.kwargs)
-        self.expected_shape = shape
-        self.expected_len = 5
-
-    def tearDown(self):
-        clean_dummy_png(self.filepath, self.filenames)
-
-class TestImageSequenceAcceptsList(_image_series, _deprecated_functions,
-                                   unittest.TestCase):
-    def setUp(self):
-        _skip_if_no_imread()
-        self.filepath = os.path.join(path, 'image_sequence')
-        self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
-                          'T76S3F00003.png', 'T76S3F00004.png',
-                          'T76S3F00005.png']
-        shape = (10, 11)
-        frames = save_dummy_png(self.filepath, self.filenames, shape)
-
-        self.filename = [os.path.join(self.filepath, fn)
-                         for fn in self.filenames]
-        self.frame0 = frames[0]
-        self.frame1 = frames[1]
-        self.kwargs = dict(plugin='matplotlib')
-        self.klass = pims.ImageSequence
-        self.v = self.klass(self.filename, **self.kwargs)
-        self.expected_shape = shape
-        self.expected_len = len(self.filenames)
-
-    def tearDown(self):
-        clean_dummy_png(self.filepath, self.filenames)
-
-class TestImageSequenceNaturalSorting(_image_series, _deprecated_functions,
-                                      unittest.TestCase):
-    def setUp(self):
-        _skip_if_no_imread()
-        self.filepath = os.path.join(path, 'image_sequence')
-        self.filenames = ['T76S3F1.png', 'T76S3F20.png',
-                     'T76S3F3.png', 'T76S3F4.png',
-                     'T76S3F50.png', 'T76S3F10.png']
-        shape = (10, 11)
-        frames = save_dummy_png(self.filepath, self.filenames, shape)
-
-        self.filename = os.path.join(self.filepath, 'T76*.png')
-        self.frame0 = frames[0]
-        self.frame1 = frames[2]
-        self.kwargs = dict(plugin='matplotlib')
-        self.klass = pims.ImageSequence
-        self.v = self.klass(self.filename, **self.kwargs)
-        self.expected_shape = shape
-        self.expected_len = len(self.filenames)
-
-    def test_sorting(self):
-        sorted_files = ['T76S3F1.png',
-                        'T76S3F3.png',
-                        'T76S3F4.png',
-                        'T76S3F10.png',
-                        'T76S3F20.png',
-                        'T76S3F50.png']
-        assert sorted_files == [x.split(os.path.sep)[-1]
-                                for x in self.v._filepaths]
-
-        # provide a list: there should be no sorting
-        self.filename = [os.path.join(self.filepath, fn) for fn in
-                         self.filenames]
-        v_unsorted = self.klass(self.filename, **self.kwargs)
-        assert self.filenames == [x.split(os.path.sep)[-1]
-                                  for x in v_unsorted._filepaths]
-
-    def tearDown(self):
-        clean_dummy_png(self.filepath, self.filenames)
-
 class TestTiffStack_pil(_tiff_image_series, _deprecated_functions,
                         unittest.TestCase):
     def check_skip(self):
@@ -718,106 +590,6 @@ class TestOpenFiles(unittest.TestCase):
     def test_open_tiff(self):
         _skip_if_no_tifffile()
         pims.open(os.path.join(path, 'stuck.tif'))
-
-
-class ImageSequenceND(_image_series, _deprecated_functions, unittest.TestCase):
-    def setUp(self):
-        _skip_if_no_imread()
-        self.filepath = os.path.join(path, 'image_sequence3d')
-        self.filenames = ['file_t001_z001_c1.png',
-                          'file_t001_z001_c2.png',
-                          'file_t001_z002_c1.png',
-                          'file_t001_z002_c2.png',
-                          'file_t002_z001_c1.png',
-                          'file_t002_z001_c2.png',
-                          'file_t002_z002_c1.png',
-                          'file_t002_z002_c2.png',
-                          'file_t003_z001_c1.png',
-                          'file_t003_z001_c2.png',
-                          'file_t003_z002_c1.png',
-                          'file_t003_z002_c2.png']
-        shape = (10, 11)
-        frames = save_dummy_png(self.filepath, self.filenames, shape)
-
-        self.filename = os.path.join(self.filepath, '*.png')
-        self.frame0 = np.array([frames[0], frames[2]])
-        self.frame1 = np.array([frames[4], frames[6]])
-        self.klass = pims.ImageSequenceND
-        self.kwargs = dict(axes_identifiers='tzc')
-        self.v = self.klass(self.filename, **self.kwargs)
-        self.v.default_coords['c'] = 0
-        self.expected_len = 3
-        self.expected_Z = 2
-        self.expected_C = 2
-        self.expected_shape = (self.expected_Z,) + shape
-
-    def tearDown(self):
-        clean_dummy_png(self.filepath, self.filenames)
-
-    def test_filename_tzc(self):
-        tzc = pims.image_sequence.filename_to_indices('file_t01_z005_c4.png')
-        self.assertEqual(tzc, [1, 5, 4])
-        tzc = pims.image_sequence.filename_to_indices('t01file_t01_z005_c4.png')
-        self.assertEqual(tzc, [1, 5, 4])
-        tzc = pims.image_sequence.filename_to_indices('file_z005_c4_t01.png')
-        self.assertEqual(tzc, [1, 5, 4])
-        tzc = pims.image_sequence.filename_to_indices(u'file\u03BC_z05_c4_t01.png')
-        self.assertEqual(tzc, [1, 5, 4])
-        tzc = pims.image_sequence.filename_to_indices('file_t9415_z005.png')
-        self.assertEqual(tzc, [9415, 5, 0])
-        tzc = pims.image_sequence.filename_to_indices('file_t47_c34.png')
-        self.assertEqual(tzc, [47, 0, 34])
-        tzc = pims.image_sequence.filename_to_indices('file_z4_c2.png')
-        self.assertEqual(tzc, [0, 4, 2])
-        tzc = pims.image_sequence.filename_to_indices('file_p4_c2_q5_r1.png',
-                                                      ['p', 'q', 'r'])
-        self.assertEqual(tzc, [4, 5, 1])
-
-    def test_sizeZ(self):
-        self.check_skip()
-        assert_equal(self.v.sizes['z'], self.expected_Z)
-
-    def test_sizeC(self):
-        self.check_skip()
-        assert_equal(self.v.sizes['c'], self.expected_C)
-
-
-class ImageSequenceND_RGB(_image_series, _deprecated_functions,
-                          unittest.TestCase):
-    def setUp(self):
-        _skip_if_no_imread()
-        self.filepath = os.path.join(path, 'image_sequence3d')
-        self.filenames = ['file_t001_z001_c1.png',
-                          'file_t001_z002_c1.png',
-                          'file_t002_z001_c1.png',
-                          'file_t002_z002_c1.png',
-                          'file_t003_z001_c1.png',
-                          'file_t003_z002_c1.png']
-        shape = (10, 11, 3)
-        frames = save_dummy_png(self.filepath, self.filenames, shape)
-
-        self.filename = os.path.join(self.filepath, '*.png')
-        self.frame0 = np.array([frames[0][:, :, 0], frames[1][:, :, 0]])
-        self.frame1 = np.array([frames[2][:, :, 0], frames[3][:, :, 0]])
-        self.klass = pims.ImageSequenceND
-        self.kwargs = dict(axes_identifiers='tz')
-        self.v = self.klass(self.filename, **self.kwargs)
-        self.v.default_coords['c'] = 0
-        self.expected_len = 3
-        self.expected_Z = 2
-        self.expected_C = 3
-        self.expected_shape = (2, 10, 11)
-
-    def test_sizeZ(self):
-        self.check_skip()
-        assert_equal(self.v.sizes['z'], self.expected_Z)
-
-    def test_sizeC(self):
-        self.check_skip()
-        assert_equal(self.v.sizes['c'], self.expected_C)
-
-    def tearDown(self):
-        clean_dummy_png(self.filepath, self.filenames)
 
 
 if __name__ == '__main__':

--- a/pims/tests/test_imseq.py
+++ b/pims/tests/test_imseq.py
@@ -114,8 +114,8 @@ class TestImageSequenceNaturalSorting(_image_series, _deprecated_functions,
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F1.png', 'T76S3F20.png',
-                     'T76S3F3.png', 'T76S3F4.png',
-                     'T76S3F50.png', 'T76S3F10.png']
+                          'T76S3F3.png', 'T76S3F4.png',
+                          'T76S3F50.png', 'T76S3F10.png']
         shape = (10, 11)
         frames = save_dummy_png(self.filepath, self.filenames, shape)
 
@@ -150,8 +150,6 @@ class TestImageSequenceNaturalSorting(_image_series, _deprecated_functions,
 
     def tearDown(self):
         clean_dummy_png(self.filepath, self.filenames)
-
-
 
 
 class ImageSequenceND(_image_series, _deprecated_functions, unittest.TestCase):
@@ -245,6 +243,37 @@ class ImageSequenceND_RGB(_image_series, _deprecated_functions,
     def test_sizeZ(self):
         self.check_skip()
         assert_equal(self.v.sizes['z'], self.expected_Z)
+
+    def test_sizeC(self):
+        self.check_skip()
+        assert_equal(self.v.sizes['c'], self.expected_C)
+
+    def tearDown(self):
+        clean_dummy_png(self.filepath, self.filenames)
+
+
+class ReaderSequence(_image_series, unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_imread()
+        self.filepath = os.path.join(path, 'image_sequence3d')
+        self.filenames = ['file001.png',
+                          'file002.png',
+                          'file003.png',
+                          'file004.png']
+        shape = (10, 11, 3)
+        frames = save_dummy_png(self.filepath, self.filenames, shape)
+
+        self.filename = os.path.join(self.filepath, '*.png')
+        self.frame0 = frames[0]
+        self.frame1 = frames[1]
+        self.klass = pims.ReaderSequence
+        self.kwargs = dict(reader_cls=pims.ImageReaderND, axis_name='t')
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.v.bundle_axes = 'yxc'
+        self.v.iter_axes = 't'
+        self.expected_len = 4
+        self.expected_C = 3
+        self.expected_shape = (10, 11, 3)
 
     def test_sizeC(self):
         self.check_skip()

--- a/pims/tests/test_imseq.py
+++ b/pims/tests/test_imseq.py
@@ -1,0 +1,254 @@
+from __future__ import (absolute_import, division, print_function,
+                        unicode_literals)
+
+import six
+
+import os
+import tempfile
+import zipfile
+import unittest
+import numpy as np
+from numpy.testing import (assert_equal, assert_allclose)
+import pims
+
+from pims.tests.test_common import (_image_series, _deprecated_functions,
+                                    clean_dummy_png, save_dummy_png,
+                                    _skip_if_no_skimage, _skip_if_no_imread)
+
+path, _ = os.path.split(os.path.abspath(__file__))
+path = os.path.join(path, 'data')
+
+
+
+
+class TestImageSequenceWithPIL(_image_series, _deprecated_functions,
+                               unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_skimage()
+        self.filepath = os.path.join(path, 'image_sequence')
+        self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
+                          'T76S3F00003.png', 'T76S3F00004.png',
+                          'T76S3F00005.png']
+        shape = (10, 11)
+        frames = save_dummy_png(self.filepath, self.filenames, shape)
+
+        self.filename = os.path.join(self.filepath, '*.png')
+        self.frame0 = frames[0]
+        self.frame1 = frames[1]
+        self.kwargs = dict(plugin='pil')
+        self.klass = pims.ImageSequence
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = shape
+        self.expected_len = 5
+        self.tempdir = tempfile.mkdtemp()
+        self.tempfile = os.path.join(self.tempdir, 'test.zip')
+
+        with zipfile.ZipFile(self.tempfile, 'w') as archive:
+            for fn in self.filenames:
+                archive.write(os.path.join(self.filepath, fn))
+
+    def test_bad_path_raises(self):
+        raises = lambda: pims.ImageSequence('this/path/does/not/exist/*.jpg')
+        self.assertRaises(IOError, raises)
+
+    def test_zipfile(self):
+        pims.ImageSequence(self.tempfile)[0]
+
+    def tearDown(self):
+        clean_dummy_png(self.filepath, self.filenames)
+        os.remove(self.tempfile)
+        os.rmdir(self.tempdir)
+
+
+class TestImageSequenceWithMPL(_image_series, _deprecated_functions,
+                               unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_skimage()
+        self.filepath = os.path.join(path, 'image_sequence')
+        self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
+                          'T76S3F00003.png', 'T76S3F00004.png',
+                          'T76S3F00005.png']
+        shape = (10, 11)
+        frames = save_dummy_png(self.filepath, self.filenames, shape)
+        self.filename = os.path.join(self.filepath, '*.png')
+        self.frame0 = frames[0]
+        self.frame1 = frames[1]
+        self.kwargs = dict(plugin='matplotlib')
+        self.klass = pims.ImageSequence
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = shape
+        self.expected_len = 5
+
+    def tearDown(self):
+        clean_dummy_png(self.filepath, self.filenames)
+
+
+class TestImageSequenceAcceptsList(_image_series, _deprecated_functions,
+                                   unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_imread()
+        self.filepath = os.path.join(path, 'image_sequence')
+        self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
+                          'T76S3F00003.png', 'T76S3F00004.png',
+                          'T76S3F00005.png']
+        shape = (10, 11)
+        frames = save_dummy_png(self.filepath, self.filenames, shape)
+
+        self.filename = [os.path.join(self.filepath, fn)
+                         for fn in self.filenames]
+        self.frame0 = frames[0]
+        self.frame1 = frames[1]
+        self.kwargs = dict(plugin='matplotlib')
+        self.klass = pims.ImageSequence
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = shape
+        self.expected_len = len(self.filenames)
+
+    def tearDown(self):
+        clean_dummy_png(self.filepath, self.filenames)
+
+
+class TestImageSequenceNaturalSorting(_image_series, _deprecated_functions,
+                                      unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_imread()
+        self.filepath = os.path.join(path, 'image_sequence')
+        self.filenames = ['T76S3F1.png', 'T76S3F20.png',
+                     'T76S3F3.png', 'T76S3F4.png',
+                     'T76S3F50.png', 'T76S3F10.png']
+        shape = (10, 11)
+        frames = save_dummy_png(self.filepath, self.filenames, shape)
+
+        self.filename = os.path.join(self.filepath, 'T76*.png')
+        self.frame0 = frames[0]
+        self.frame1 = frames[2]
+        self.kwargs = dict(plugin='matplotlib')
+        self.klass = pims.ImageSequence
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = shape
+        self.expected_len = len(self.filenames)
+
+    def test_sorting(self):
+        sorted_files = ['T76S3F1.png',
+                        'T76S3F3.png',
+                        'T76S3F4.png',
+                        'T76S3F10.png',
+                        'T76S3F20.png',
+                        'T76S3F50.png']
+
+        assert sorted_files == [x.split(os.path.sep)[-1]
+                                for x in self.v._filepaths]
+
+        # provide a list: there should be no sorting
+        self.filename = [os.path.join(self.filepath, fn) for fn in
+                         self.filenames]
+        v_unsorted = self.klass(self.filename, **self.kwargs)
+
+        assert self.filenames == [x.split(os.path.sep)[-1]
+                                  for x in v_unsorted._filepaths]
+
+
+    def tearDown(self):
+        clean_dummy_png(self.filepath, self.filenames)
+
+
+
+
+class ImageSequenceND(_image_series, _deprecated_functions, unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_imread()
+        self.filepath = os.path.join(path, 'image_sequence3d')
+        self.filenames = ['file_t001_z001_c1.png',
+                          'file_t001_z001_c2.png',
+                          'file_t001_z002_c1.png',
+                          'file_t001_z002_c2.png',
+                          'file_t002_z001_c1.png',
+                          'file_t002_z001_c2.png',
+                          'file_t002_z002_c1.png',
+                          'file_t002_z002_c2.png',
+                          'file_t003_z001_c1.png',
+                          'file_t003_z001_c2.png',
+                          'file_t003_z002_c1.png',
+                          'file_t003_z002_c2.png']
+        shape = (10, 11)
+        frames = save_dummy_png(self.filepath, self.filenames, shape)
+
+        self.filename = os.path.join(self.filepath, '*.png')
+        self.frame0 = np.array([frames[0], frames[2]])
+        self.frame1 = np.array([frames[4], frames[6]])
+        self.klass = pims.ImageSequenceND
+        self.kwargs = dict(axes_identifiers='tzc')
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.v.default_coords['c'] = 0
+        self.expected_len = 3
+        self.expected_Z = 2
+        self.expected_C = 2
+        self.expected_shape = (self.expected_Z,) + shape
+
+    def tearDown(self):
+        clean_dummy_png(self.filepath, self.filenames)
+
+    def test_filename_tzc(self):
+        tzc = pims.image_sequence.filename_to_indices('file_t01_z005_c4.png')
+        self.assertEqual(tzc, [1, 5, 4])
+        tzc = pims.image_sequence.filename_to_indices('t01file_t01_z005_c4.png')
+        self.assertEqual(tzc, [1, 5, 4])
+        tzc = pims.image_sequence.filename_to_indices('file_z005_c4_t01.png')
+        self.assertEqual(tzc, [1, 5, 4])
+        tzc = pims.image_sequence.filename_to_indices(u'file\u03BC_z05_c4_t01.png')
+        self.assertEqual(tzc, [1, 5, 4])
+        tzc = pims.image_sequence.filename_to_indices('file_t9415_z005.png')
+        self.assertEqual(tzc, [9415, 5, 0])
+        tzc = pims.image_sequence.filename_to_indices('file_t47_c34.png')
+        self.assertEqual(tzc, [47, 0, 34])
+        tzc = pims.image_sequence.filename_to_indices('file_z4_c2.png')
+        self.assertEqual(tzc, [0, 4, 2])
+        tzc = pims.image_sequence.filename_to_indices('file_p4_c2_q5_r1.png',
+                                                      ['p', 'q', 'r'])
+        self.assertEqual(tzc, [4, 5, 1])
+
+    def test_sizeZ(self):
+        self.check_skip()
+        assert_equal(self.v.sizes['z'], self.expected_Z)
+
+    def test_sizeC(self):
+        self.check_skip()
+        assert_equal(self.v.sizes['c'], self.expected_C)
+
+
+class ImageSequenceND_RGB(_image_series, _deprecated_functions,
+                          unittest.TestCase):
+    def setUp(self):
+        _skip_if_no_imread()
+        self.filepath = os.path.join(path, 'image_sequence3d')
+        self.filenames = ['file_t001_z001_c1.png',
+                          'file_t001_z002_c1.png',
+                          'file_t002_z001_c1.png',
+                          'file_t002_z002_c1.png',
+                          'file_t003_z001_c1.png',
+                          'file_t003_z002_c1.png']
+        shape = (10, 11, 3)
+        frames = save_dummy_png(self.filepath, self.filenames, shape)
+
+        self.filename = os.path.join(self.filepath, '*.png')
+        self.frame0 = np.array([frames[0][:, :, 0], frames[1][:, :, 0]])
+        self.frame1 = np.array([frames[2][:, :, 0], frames[3][:, :, 0]])
+        self.klass = pims.ImageSequenceND
+        self.kwargs = dict(axes_identifiers='tz')
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.v.default_coords['c'] = 0
+        self.expected_len = 3
+        self.expected_Z = 2
+        self.expected_C = 3
+        self.expected_shape = (2, 10, 11)
+
+    def test_sizeZ(self):
+        self.check_skip()
+        assert_equal(self.v.sizes['z'], self.expected_Z)
+
+    def test_sizeC(self):
+        self.check_skip()
+        assert_equal(self.v.sizes['c'], self.expected_C)
+
+    def tearDown(self):
+        clean_dummy_png(self.filepath, self.filenames)

--- a/pims/tests/test_multidimensional.py
+++ b/pims/tests/test_multidimensional.py
@@ -5,6 +5,7 @@ import six
 
 import unittest
 import nose
+from nose.tools import assert_raises
 from itertools import chain, permutations
 import numpy as np
 from numpy.testing import assert_equal
@@ -104,6 +105,33 @@ class TestMultidimensional(unittest.TestCase):
 
         # if a metadata field is equal for all frames, it should be a scalar
         assert_equal(md['t'], 15)
+
+    def test_mutability(self):
+        # test for issues that may arise when properties return mutable objects
+
+        # the list bundle_axes
+        self.v.bundle_axes = ['z', 'y', 'x']
+        temp = self.v.bundle_axes
+        temp = []
+        assert_equal(self.v[0].shape, (20, 1, 6))
+
+        # the list iter_axes
+        self.v.iter_axes = ['t']
+        temp = self.v.iter_axes
+        temp = []
+        assert_equal(len(self.v), 100)
+
+        # the dict default_coords
+        # changing an nonexisting item on a copy does nothing
+        a = dict(self.v.default_coords)
+        a['non_existing'] = 0
+        # but assigning it again raises
+        with assert_raises(ValueError) as cm:
+            self.v.default_coords = a
+
+        # changing an nonexisting item should raise
+        with assert_raises(ValueError) as cm:
+            self.v.default_coords['non_existing'] = 0
 
 
 class RandomReaderFlexible(FramesSequenceND):


### PR DESCRIPTION
I have added a class `ReaderSequence` that reads a sequence of N-dimensional files, adding an extra axis. Not to be mistaken with `ImageSequenceND`, which reads a sequence of 2-dimensional files into an N-dimensional reader.

For example, `ReaderSequence(filenames, pims.Bioformats, axis_name='p')` reads a series of N-dimensional files using the Bioformats reader, and adds them together on a new axis called `p`. 
It is not possible to bundle this axis, you can only iterate over it.

For the tests I implemented a simple wrapper around `imread` that reads a single image into a lengh-1 reader, both from the 'normal' `FramesSequence` (`ImageReader`) or as an N-dimensional `FramesSequenceND` (`ImageReaderND`). That solves issue #221 .