### PR TITLE
CLN Remove dtype, process_func and as_gray kwargs

### DIFF
--- a/doc/source/index.rst
+++ b/doc/source/index.rst
@@ -18,6 +18,7 @@ Contents
    release_notes
    opening_files
    slicing
+   pipelines
    frame
    multidimensional
    custom_readers

--- a/doc/source/pipelines.rst
+++ b/doc/source/pipelines.rst
@@ -1,0 +1,115 @@
+Pipelines
+=========
+
+.. ipython:: python
+   :suppress:
+
+   from pims.tests.test_common import save_dummy_png, clean_dummy_png
+   filenames = ['img-{0}.png'.format(i) for i in range(9)]
+   save_dummy_png('.', filenames, (256, 256, 3))
+   from pims import ImageSequence
+   video = ImageSequence('img-*.png')
+
+   def _as_grey(frame):
+       red = frame[:, :, 0]
+       green = frame[:, :, 1]
+       blue = frame[:, :, 2]
+       return 0.2125 * red + 0.7154 * green + 0.0721 * blue
+
+   from slicerator import pipeline
+   as_grey = pipeline(_as_grey)
+
+Videos loaded by pims are (``FramesSequence`` objects) are like lists of numpy
+arrays. Unlike Python lists of arrays they are "lazy", they only load the data
+from the harddrive when it is necessary.
+
+In order to modify a ``FramesSequence``, for instance to convert RGB color
+videos to grayscale, one could load all the video frames in memory and do the
+conversion. THis however costs a lot of time and memory, and for very large
+videos this is just not feasible. To solve this problem, PIMS uses
+so-called pipeline decorators from a sister project called ``slicerator``.
+A pipeline-decorated function is only evaluated when needed, so that the
+underlying video data is only accessed one element at a time.
+
+Conversion to greyscale
+-----------------------
+
+Say we want to convert an RGB video to greyscale. We define a function as
+follows and decorate it with ``@pipeline`` to turn it into a pipeline:
+
+.. code-block:: python
+
+   from slicerator import pipeline  # or: from pims import pipeline
+
+   @pipeline
+   def as_grey(frame):
+       red = frame[:, :, 0]
+       green = frame[:, :, 1]
+       blue = frame[:, :, 2]
+       return 0.2125 * red + 0.7154 * green + 0.0721 * blue
+
+
+The behavior of ``as_grey`` is unchanged if it is used on a single frame:
+
+.. ipython:: python
+
+   frame = video[0]
+   print(frame.shape)   # the shape of the example video is RGB
+   processed_frame = as_grey(video[0])
+   print(processed_frame.shape)  # the converted frame is indeed greyscale
+
+
+However, the ``@pipeline`` decorator enables lazy evaluation of full videos:
+
+.. ipython:: python
+
+   processed_video = as_grey(video)  # this would not be possible without @pipeline
+   # nothing has been converted yet!
+
+   processed_frame = processed_video[0]  # now the conversion takes place
+   print(processed_frame.shape)
+
+Please keep in mind that these simple pipelines do not change the reader
+properties, such as ``video.frame_shape``.
+
+
+Converting existing functions to a pipeline
+-------------------------------------------
+
+.. note:: This supersedes the ``process_func`` and ``as_grey`` reader keyword
+ arguments starting from PIMS v0.4
+
+We are now going to do exactly the same greyscale conversion, but using an
+existing function from ``skimage``:
+
+.. ipython:: python
+
+   from skimage.color import rgb2gray
+   rgb2gray_pipeline = pipeline(rgb2gray)
+   processed_video = rgb2gray_pipeline(video)
+   processed_frame = processed_video[0]
+   print(processed_frame.shape)
+
+
+Any function that takes a single frame and returns a single frame can be converted
+into a pipeline in this way.
+
+
+Dtype conversion using lambda functions
+---------------------------------------
+
+.. note:: This supersedes the ``dtype`` reader keyword argument starting from PIMS v0.4
+
+We are now going to convert the data type of a video to float using an
+unnamed lambda function in a single line:
+
+.. ipython:: python
+
+   processed_video = pipeline(lambda x: x.astype(np.float))(video)
+   processed_frame = processed_video[0]
+   print(processed_frame.shape)
+
+.. ipython:: python
+   :suppress:
+
+   clean_dummy_png('.', filenames)

--- a/doc/source/pipelines.rst
+++ b/doc/source/pipelines.rst
@@ -19,13 +19,13 @@ Pipelines
    from slicerator import pipeline
    as_grey = pipeline(_as_grey)
 
-Videos loaded by pims are (``FramesSequence`` objects) are like lists of numpy
+Videos loaded by pims (``FramesSequence`` objects) are like lists of numpy
 arrays. Unlike Python lists of arrays they are "lazy", they only load the data
 from the harddrive when it is necessary.
 
 In order to modify a ``FramesSequence``, for instance to convert RGB color
 videos to grayscale, one could load all the video frames in memory and do the
-conversion. THis however costs a lot of time and memory, and for very large
+conversion. This however costs a lot of time and memory, and for very large
 videos this is just not feasible. To solve this problem, PIMS uses
 so-called pipeline decorators from a sister project called ``slicerator``.
 A pipeline-decorated function is only evaluated when needed, so that the
@@ -55,7 +55,7 @@ The behavior of ``as_grey`` is unchanged if it is used on a single frame:
 
    frame = video[0]
    print(frame.shape)   # the shape of the example video is RGB
-   processed_frame = as_grey(video[0])
+   processed_frame = as_grey(frame)
    print(processed_frame.shape)  # the converted frame is indeed greyscale
 
 
@@ -69,8 +69,15 @@ However, the ``@pipeline`` decorator enables lazy evaluation of full videos:
    processed_frame = processed_video[0]  # now the conversion takes place
    print(processed_frame.shape)
 
+This means that the modified video can be used exactly as you would use the
+original one. In most cases, it will look as though you are accessing
+a grayscale video file, even though the file on disk is still in color.
 Please keep in mind that these simple pipelines do not change the reader
-properties, such as ``video.frame_shape``.
+properties, such as ``video.frame_shape``. Propagating metadata properly through
+pipelines is partly implemented, but currently still experimental.
+For a detailed description of this tricky point, please consult
+`this <https://github.com/soft-matter/slicerator/pull/5#issuecomment-143560978>`_
+discussion on GitHub.
 
 
 Converting existing functions to a pipeline

--- a/doc/source/release_notes.rst
+++ b/doc/source/release_notes.rst
@@ -1,6 +1,12 @@
 Release notes
 =============
 
+v0.5
+----
+- API: all readers do not support the keyword arguments ``process_func``,
+  ``dtype`` and ``as_grey`` anymore. Please consult the documentation on
+  Pipelines on how to convert videos. (see :doc:`pipelines`) (PR 250)
+
 v0.4
 ----
 - API: N-dimensional readers now smartly use ``get_frame`` methods; depending on
@@ -27,6 +33,10 @@ v0.4
 - Added a video exporter based on MoviePy (PR 233)
 - Added ``BioformatsReader.metadata.fields`` that lists all metadata fields. (PR 230)
 
+v0.3.4
+------
+- API: Swap elements of ``frame_shape`` in ``SpeStack`` to match frames'
+  ``shape``.
 
 v0.3.3
 ------

--- a/pims/ffmpeg_reader.py
+++ b/pims/ffmpeg_reader.py
@@ -128,8 +128,7 @@ class FFmpegVideoReader(FramesSequence):
     >>> frame_shape = video.frame_shape # Pixel dimensions of video
 
     """
-    def __init__(self, filename, process_func=None, pix_fmt="rgb24",
-                 use_cache=True, as_grey=False):
+    def __init__(self, filename, pix_fmt="rgb24", use_cache=True):
 
         self.filename = filename
         self.pix_fmt = pix_fmt
@@ -140,9 +139,6 @@ class FFmpegVideoReader(FramesSequence):
             raise ValueError("invalid pixel format")
         w, h = self._size
         self._stride = self.depth*w*h
-
-        self._validate_process_func(process_func)
-        self._as_grey(as_grey, process_func)
 
     def _initialize(self, use_cache):
         """ Opens the file, creates the pipe. """
@@ -228,11 +224,11 @@ class FFmpegVideoReader(FramesSequence):
         w, h = self._size
         result = np.fromstring(s,
             dtype='uint8').reshape((h, w, self.depth))
-        return Frame(self.process_func(result), frame_no=j)
+        return Frame(result, frame_no=j)
 
     @property
     def pixel_type(self):
-        raise NotImplemented()
+        raise np.uint8
 
     @classmethod
     def class_exts(cls):

--- a/pims/spe_stack.py
+++ b/pims/spe_stack.py
@@ -191,7 +191,7 @@ class SpeStack(FramesSequence):
             # Use the file size to determine the number of frames
             fsz = os.path.getsize(filename)
             l = fsz - Spec.data_start
-            l //= self._width * self._height * self._file_dtype.itemsize
+            l //= self._width * self._height * self._dtype.itemsize
             if l != self._len:
                 warnings.warn("Number of frames according to file header "
                               "does not match the size of file " +

--- a/pims/spe_stack.py
+++ b/pims/spe_stack.py
@@ -133,23 +133,13 @@ class SpeStack(FramesSequence):
     def class_exts(cls):
         return {"spe"} | super(SpeStack, cls).class_exts()
 
-    def __init__(self, filename, process_func=None, dtype=None,
-                 as_grey=False, char_encoding=None, check_filesize=True):
+    def __init__(self, filename, char_encoding=None, check_filesize=True):
         """Create an iterable object that returns image data as numpy arrays
 
         Arguments
         ---------
         filename : string
             Name of the SPE file
-        process_func : callable or None, optional
-            Takes one image array as its sole argument. It is applied to each
-            image. Defaults to None.
-        dtype : numpy.dtype, optional
-            Which data type to convert the images too. No conversion if None.
-            Defaults to None.
-        as_grey : bool, optional
-            Convert image to greyscale. Do not use in conjunction with
-            process_func. Defaults to False.
         char_encoding : str or None, optional
             Specifies what character encoding is used to decode metatdata
             strings. If None, use the `default_char_encoding` class attribute.
@@ -189,11 +179,7 @@ class SpeStack(FramesSequence):
 
         ### Some metadata is "special", deal with it
         #Determine data type
-        self._file_dtype = Spec.dtypes[self.metadata.pop("datatype")]
-        if dtype is None:
-            self._dtype = self._file_dtype
-        else:
-            self._dtype = dtype
+        self._dtype = Spec.dtypes[self.metadata.pop("datatype")]
 
         #movie dimensions
         self._width = self.metadata.pop("xdim")
@@ -247,10 +233,6 @@ class SpeStack(FramesSequence):
         else:
             self.metadata.pop("readoutMode", None)
 
-        ### pims-specific stuff
-        self._validate_process_func(process_func)
-        self._as_grey(as_grey, process_func)
-
     @property
     def frame_shape(self):
         return self._height, self._width
@@ -262,14 +244,11 @@ class SpeStack(FramesSequence):
         if j >= self._len:
             raise ValueError("Frame number {} out of range.".format(j))
         self._file.seek(Spec.data_start
-                        + j*self._width*self._height*self._file_dtype.itemsize)
-        data = np.fromfile(self._file, dtype=self._file_dtype,
+                        + j*self._width*self._height*self.pixel_type.itemsize)
+        data = np.fromfile(self._file, dtype=self.pixel_type,
                            count=self._width*self._height)
-        if self._dtype != self._file_dtype:
-            data = data.astype(self._dtype)
-        return Frame(
-            self.process_func(data.reshape(self._height, self._width)),
-            frame_no=j, metadata=self.metadata)
+        return Frame(data.reshape(self._height, self._width),
+                     frame_no=j, metadata=self.metadata)
 
     def close(self):
         """Clean up and close file"""

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -257,7 +257,6 @@ class TestRecursiveSlicing(unittest.TestCase):
         assert_true(isinstance(slice2, types.GeneratorType))
 
 def _rescale(img):
-    # print(type(img))
     return (img - img.min()) / img.ptp()
 
 def _color_channel(img, channel):

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -398,27 +398,6 @@ class _image_series(_image_single):
         list(self.v[[0, -1]])
 
 
-class _image_rgb(_image_single):
-    # Only include these tests for 2D RGB files.
-    def test_greyscale_process_func(self):
-        self.check_skip()
-        def greyscale(image):
-            assert image.ndim == 3
-            image = image[:, :, 0]
-            assert image.ndim == 2
-            return image
-
-        v_raw = self.klass(self.filename, **self.kwargs)
-        v = self.klass(self.filename, greyscale, **self.kwargs)
-        assert_image_equal(v[0], greyscale(v_raw[0]))
-
-    def test_as_grey(self):
-        self.check_skip()
-        v = self.klass(self.filename, as_grey=True, **self.kwargs)
-        ndim = v[0].ndim
-        self.assertEqual(ndim, 2)
-
-
 class TestImageReaderTIFF(_image_single, unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
@@ -474,7 +453,7 @@ class TestVideo_PyAV_timed(_image_series, unittest.TestCase):
         self.expected_len = 480
 
 
-class TestVideo_PyAV_indexed(_image_series, _image_rgb, _deprecated_functions,
+class TestVideo_PyAV_indexed(_image_series, _deprecated_functions,
                              unittest.TestCase):
     def check_skip(self):
         _skip_if_no_PyAV()
@@ -706,8 +685,7 @@ class TestTiffStack_tifffile(_tiff_image_series, unittest.TestCase):
         self.expected_len = 5
 
 
-class TestSpeStack(_image_series, _deprecated_functions,
-                   unittest.TestCase):
+class TestSpeStack(_image_series, unittest.TestCase):
     def check_skip(self):
         pass
 

--- a/pims/tests/test_frame.py
+++ b/pims/tests/test_frame.py
@@ -66,8 +66,8 @@ def test_copy_update_md():
     tt = Frame(tt_base, frame_no=frame_no, metadata=md_dict2)
     target_dict = dict(md_dict)
     target_dict.update(md_dict2)
-    print(target_dict)
-    print(tt.metadata)
+    # print(target_dict)
+    # print(tt.metadata)
     assert_equal(tt.metadata, target_dict)
 
     tt2 = Frame(tt_base, frame_no=frame_no, metadata=md_dict3)

--- a/pims/tests/test_imseq.py
+++ b/pims/tests/test_imseq.py
@@ -11,7 +11,7 @@ import numpy as np
 from numpy.testing import (assert_equal, assert_allclose)
 import pims
 
-from pims.tests.test_common import (_image_series, _deprecated_functions,
+from pims.tests.test_common import (_image_series,
                                     clean_dummy_png, save_dummy_png,
                                     _skip_if_no_skimage, _skip_if_no_imread)
 
@@ -21,8 +21,7 @@ path = os.path.join(path, 'data')
 
 
 
-class TestImageSequenceWithPIL(_image_series, _deprecated_functions,
-                               unittest.TestCase):
+class TestImageSequenceWithPIL(_image_series, unittest.TestCase):
     def setUp(self):
         _skip_if_no_skimage()
         self.filepath = os.path.join(path, 'image_sequence')
@@ -60,8 +59,7 @@ class TestImageSequenceWithPIL(_image_series, _deprecated_functions,
         os.rmdir(self.tempdir)
 
 
-class TestImageSequenceWithMPL(_image_series, _deprecated_functions,
-                               unittest.TestCase):
+class TestImageSequenceWithMPL(_image_series, unittest.TestCase):
     def setUp(self):
         _skip_if_no_skimage()
         self.filepath = os.path.join(path, 'image_sequence')
@@ -83,8 +81,7 @@ class TestImageSequenceWithMPL(_image_series, _deprecated_functions,
         clean_dummy_png(self.filepath, self.filenames)
 
 
-class TestImageSequenceAcceptsList(_image_series, _deprecated_functions,
-                                   unittest.TestCase):
+class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
@@ -108,8 +105,7 @@ class TestImageSequenceAcceptsList(_image_series, _deprecated_functions,
         clean_dummy_png(self.filepath, self.filenames)
 
 
-class TestImageSequenceNaturalSorting(_image_series, _deprecated_functions,
-                                      unittest.TestCase):
+class TestImageSequenceNaturalSorting(_image_series, unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
@@ -152,7 +148,7 @@ class TestImageSequenceNaturalSorting(_image_series, _deprecated_functions,
         clean_dummy_png(self.filepath, self.filenames)
 
 
-class ImageSequenceND(_image_series, _deprecated_functions, unittest.TestCase):
+class ImageSequenceND(_image_series, unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')
@@ -214,8 +210,7 @@ class ImageSequenceND(_image_series, _deprecated_functions, unittest.TestCase):
         assert_equal(self.v.sizes['c'], self.expected_C)
 
 
-class ImageSequenceND_RGB(_image_series, _deprecated_functions,
-                          unittest.TestCase):
+class ImageSequenceND_RGB(_image_series, unittest.TestCase):
     def setUp(self):
         _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')

--- a/pims/tests/test_norpix.py
+++ b/pims/tests/test_norpix.py
@@ -115,37 +115,37 @@ class test_defaults(_norpix6_sample_tests, unittest.TestCase):
         assert self.seq[0].dtype == np.uint8
 
 
-class test_dtype(_norpix6_sample_tests, unittest.TestCase):
-    def setUp(self):
-        self.options = {}
-        self.dtype = np.float_
-        self.options['dtype'] = self.dtype
-        super(test_dtype, self).setUp()
-
-    def test_dtype(self):
-        fr = self.seq[0]
-        assert fr.dtype == self.dtype
-
-
-class test_process_func(_norpix6_sample_tests, unittest.TestCase):
-    def setUp(self):
-        self.options = {}
-        self.options['dtype'] = np.float_
-        self.options['process_func'] = lambda x: -x
-        super(test_process_func, self).setUp()
-
-    def test_process_func(self):
-        fr = self.seq[0]
-        assert np.all(fr <= 0)
+# class test_dtype(_norpix6_sample_tests, unittest.TestCase):
+#     def setUp(self):
+#         self.options = {}
+#         self.dtype = np.float_
+#         self.options['dtype'] = self.dtype
+#         super(test_dtype, self).setUp()
+#
+#     def test_dtype(self):
+#         fr = self.seq[0]
+#         assert fr.dtype == self.dtype
+#
+#
+# class test_process_func(_norpix6_sample_tests, unittest.TestCase):
+#     def setUp(self):
+#         self.options = {}
+#         self.options['dtype'] = np.float_
+#         self.options['process_func'] = lambda x: -x
+#         super(test_process_func, self).setUp()
+#
+#     def test_process_func(self):
+#         fr = self.seq[0]
+#         assert np.all(fr <= 0)
 
 
 class test_as_raw(_norpix6_sample_tests, unittest.TestCase):
     def setUp(self):
         self.options = {'as_raw': True}
         super(test_as_raw, self).setUp()
-
-    def test_post_hoc_process_func(self):
-        testbyte = self.seq[0][0,0]
-        self.seq.set_process_func(lambda x: 255 - x)
-        assert self.seq[0][0,0] == 255 - testbyte
+    #
+    # def test_post_hoc_process_func(self):
+    #     testbyte = self.seq[0][0,0]
+    #     self.seq.set_process_func(lambda x: 255 - x)
+    #     assert self.seq[0][0,0] == 255 - testbyte
 


### PR DESCRIPTION
As discussed previously, this removes the `dtype`, `process_func` and `as_gray` kwargs from all readers. The newer readers already did not have them. Just for reference, the way we now expose these functionalities is through Pipelines:

    @pipeline
    def add_one(frame):
        return frame + 1

    reader_proc = add_one(reader)

Or cast it to a different dtype:

    reader_proc = pipeline(lambda x: x.astype(np.float))(reader)

Or a simple as_gray:

    reader_proc = pipeline(lambda x.sum(axis=2))(reader)

Todo is implement a smarter as_gray function, but that will have to wait until #247 (to avoid a messy rebase)