### PR TITLE
BUG Wrong frame_shape for pyav reader

### DIFF
--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -90,7 +90,7 @@ class PyAVVideoReader(FramesSequence):
                         if isinstance(s, av.video.VideoStream)][0]
         # PyAV always returns frames in color, and we make that
         # assumption in get_frame() later below, so 3 is hardcoded here:
-        self._im_sz = video_stream.width, video_stream.height, 3
+        self._im_sz = video_stream.height, video_stream.width, 3
 
         del container  # The generator is empty. Reload the file.
         self._load_fresh_file()

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -121,6 +121,7 @@ class _image_single(object):
     def test_shape(self):
         self.check_skip()
         assert_equal(self.v.frame_shape, self.expected_shape)
+        assert_equal(self.v[0].shape, self.expected_shape)
 
     def test_count(self):
         self.check_skip()
@@ -437,7 +438,7 @@ class TestVideo_PyAV(_image_series, _image_rgb, _deprecated_functions,
         self.klass = pims.PyAVVideoReader
         self.kwargs = dict()
         self.v = self.klass(self.filename, **self.kwargs)
-        self.expected_shape = (640, 424, 3)  # (x, y), wrong convention?
+        self.expected_shape = (424, 640, 3)
         self.expected_len = 480
 
 


### PR DESCRIPTION
The pyav was returning the images OK, only the `frame_shape` was wrong. I have added a test for both `v.frame_shape` and `v[0].shape` and fixed the `frame_shape`.

Fixes #234 