### PR TITLE
ENH Timed PyAv reader

### DIFF
--- a/pims/api.py
+++ b/pims/api.py
@@ -34,13 +34,18 @@ if export is None:
 try:
     import pims.pyav_reader
     if pims.pyav_reader.available():
-        PyAVVideoReader = pims.pyav_reader.PyAVVideoReader
-        Video = PyAVVideoReader
+        PyAVReaderTimed = pims.pyav_reader.PyAVReaderTimed
+        PyAVReaderIndexed = pims.pyav_reader.PyAVReaderIndexed
+        Video = PyAVReaderTimed
     else:
         raise ImportError()
 except (ImportError, IOError):
-    PyAVVideoReader = not_available("PyAV and/or PIL/Pillow")
+    PyAVVideoReader = not_available("PyAV")
+    PyAVReaderTimed = not_available("PyAV")
+    PyAVReaderIndexed = not_available("PyAV")
     Video = None
+
+PyAVVideoReader = PyAVReaderTimed
 
 
 try:

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -225,7 +225,11 @@ class PyAVReaderTimed(FramesSequence):
         try:
             frame = next(self._frame_generator)
         except StopIteration:
-            return None
+            self._reset_demuxer()
+            try:
+                frame = next(self._frame_generator)
+            except StopIteration:
+                return None
 
         if i == 0:  # security measure to avoid infinite recursion
             return frame

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -378,7 +378,7 @@ class PyAVReaderIndexed(FramesSequence):
 
     @property
     def pixel_type(self):
-        raise NotImplemented()
+        raise np.uint8
 
     def __repr__(self):
         # May be overwritten by subclasses

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -461,8 +461,7 @@ class TestImageReaderND(_image_single, unittest.TestCase):
         clean_dummy_png(path, ['dummy.png'])
 
 
-class TestVideo_PyAV(_image_series, _image_rgb, _deprecated_functions,
-                     unittest.TestCase):
+class TestVideo_PyAV_timed(_image_series, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_PyAV()
 
@@ -471,7 +470,24 @@ class TestVideo_PyAV(_image_series, _image_rgb, _deprecated_functions,
         self.filename = os.path.join(path, 'bulk-water.mov')
         self.frame0 = np.load(os.path.join(path, 'bulk-water_frame0.npy'))
         self.frame1 = np.load(os.path.join(path, 'bulk-water_frame1.npy'))
-        self.klass = pims.PyAVVideoReader
+        self.klass = pims.PyAVReaderTimed
+        self.kwargs = dict()
+        self.v = self.klass(self.filename, **self.kwargs)
+        self.expected_shape = (424, 640, 3)
+        self.expected_len = 480
+
+
+class TestVideo_PyAV_indexed(_image_series, _image_rgb, _deprecated_functions,
+                             unittest.TestCase):
+    def check_skip(self):
+        _skip_if_no_PyAV()
+
+    def setUp(self):
+        _skip_if_no_PyAV()
+        self.filename = os.path.join(path, 'bulk-water.mov')
+        self.frame0 = np.load(os.path.join(path, 'bulk-water_frame0.npy'))
+        self.frame1 = np.load(os.path.join(path, 'bulk-water_frame1.npy'))
+        self.klass = pims.PyAVReaderIndexed
         self.kwargs = dict()
         self.v = self.klass(self.filename, **self.kwargs)
         self.expected_shape = (424, 640, 3)


### PR DESCRIPTION
A wrapper around PyAv that interprets `duration`, `average_rate` and the timestamps per frame to give a reader with the indexed based on the timestamp of each frame. Missing frames are inserted as black frames.

Also I dropped the `PIL` dependency of the index-based PyAv reader.