### PR TITLE
FIX Two fixes for the pyavreader

### DIFF
--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -228,8 +228,8 @@ class PyAVReaderTimed(FramesSequence):
         self._cache = [None] * len(self._cache)
         # the ffmpeg decode cache is flushed automatically
 
-        timestamp = int(i / self.frame_rate * av.time_base)
-        self._container.seek(timestamp)
+        timestamp = int(i / (self._frame_rate * self._stream.time_base))
+        self._stream.seek(timestamp + self._first_pts)
 
         # check the first frame
         try:

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -209,8 +209,6 @@ class PyAVReaderTimed(FramesSequence):
         if result is None:
             # the requested frame actually does not exist. Can occur due to
             # a bad file, or due to inaccuracy of reader length __len__.
-            warn("Frame {} could not be found. Returning the last non-empty "
-                 "frame.".format(i))
             # find it in the cache
             for other_i in range(i - 1, i - len(self._cache), -1):
                 result = self._cache[other_i % len(self._cache)]

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -205,12 +205,20 @@ class PyAVReaderTimed(FramesSequence):
         if result is None:
             # the requested frame actually does not exist. Can occur due to
             # a bad file, or due to inaccuracy of reader length __len__.
-            warn("Frame {} could not be found. Returning an "
-                 "empty frame.".format(i))
-            return Frame(np.zeros(self.frame_shape, dtype=self.pixel_type),
-                         frame_no=i)
-        else:
-            return result.to_frame()
+            warn("Frame {} could not be found. Returning the last non-empty "
+                 "frame.".format(i))
+            # find it in the cache
+            for other_i in range(i - 1, i - len(self._cache), -1):
+                result = self._cache[other_i % len(self._cache)]
+                if result is None:
+                    continue
+                if result.frame_no < i:
+                    break
+            else:  # cache is empty: return an empty frame
+                return Frame(np.zeros(self.frame_shape, dtype=self.pixel_type),
+                             frame_no=i)
+
+        return result.to_frame()
 
     def seek(self, i):
         """Seek to a frame before i and return the first frame."""


### PR DESCRIPTION
Some videos have missing frames, which is mainly caused by codecs that remove frames that are very similar. Therefore the most logical choice seems to return the latest non-empty frame, and not a black frame.

Also, this adds some extra checks when opening the file and the possibility for using video files with multiple video streams.