### PR TITLE
Use availability functions to check tests to skip

### DIFF
--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -38,16 +38,14 @@ def _skip_if_no_ImageIO():
 
 
 def _skip_if_no_libtiff():
-    try:
-        import libtiff
-    except ImportError:
+    import pims.tiff_stack
+    if not pims.tiff_stack.libtiff_available():
         raise nose.SkipTest('libtiff not installed. Skipping.')
 
 
 def _skip_if_no_tifffile():
-    try:
-        import tifffile
-    except ImportError:
+    import pims.tiff_stack
+    if not pims.tiff_stack.tifffile_available():
         raise nose.SkipTest('tifffile not installed. Skipping.')
 
 
@@ -65,9 +63,8 @@ def _skip_if_no_skimage():
 
 
 def _skip_if_no_PIL():
-    try:
-        from PIL import Image
-    except ImportError:
+    import pims.tiff_stack
+    if not pims.tiff_stack.PIL_available():
         raise nose.SkipTest('PIL/Pillow not installed. Skipping.')
 
 


### PR DESCRIPTION
Instead of trying to deduce what functionality may or may not be present by using imports, simply use the availability function to determine if the functionality is present or not. This way we can rely on whatever is the best strategy for that module when running the tests for it. Also this gives us the opportunity to verify that the availability functions are working as intended.