### PR TITLE
Try scikit-image if tifffile is not available

### DIFF
--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -22,7 +22,10 @@ except ImportError:
 try:
     import tifffile
 except ImportError:
-    tifffile = None
+    try:
+        from skimage.external import tifffile
+    except ImportError:
+        tifffile = None
 
 
 def libtiff_available():


### PR DESCRIPTION
In the event that the user does not have `tifffile` installed, but does have `scikit-image` installed, try to import `tifffile` from `scikit-image`'s `external` package. If that still doesn't work, gracefully proceed to marking `tifffile` as missing.