### PR TITLE
FIX Floating point issue for pyav export framerate

### DIFF
--- a/pims/display.py
+++ b/pims/display.py
@@ -119,7 +119,9 @@ def export_pyav(sequence, filename, rate=30, bitrate=None,
             raise NotImplemented
 
     output = av.open(str(filename), str('w'), format=format, options=options)
-    stream = output.add_stream(codec, rate=export_rate)
+    # Maximum allowed timebase is 66535 for mpeg4: round rate to 4 decimals.
+    # see https://github.com/mikeboers/PyAV/issues/242
+    stream = output.add_stream(codec, rate='{0:.4f}'.format(export_rate))
     stream.pix_fmt = str(pixel_format)
 
     for frame_no in itertools.count():

--- a/pims/display.py
+++ b/pims/display.py
@@ -9,6 +9,7 @@ import tempfile
 from io import BytesIO
 from base64 import b64encode
 from contextlib import contextmanager
+from fractions import Fraction
 import warnings
 
 try:
@@ -119,9 +120,10 @@ def export_pyav(sequence, filename, rate=30, bitrate=None,
             raise NotImplemented
 
     output = av.open(str(filename), str('w'), format=format, options=options)
-    # Maximum allowed timebase is 66535 for mpeg4: round rate to 4 decimals.
+    # Maximum allowed timebase is 66535 (at least for mpeg4)
     # see https://github.com/mikeboers/PyAV/issues/242
-    stream = output.add_stream(codec, rate='{0:.4f}'.format(export_rate))
+    export_rate_frac = Fraction(export_rate).limit_denominator(65535)
+    stream = output.add_stream(codec, rate=export_rate_frac)
     stream.pix_fmt = str(pixel_format)
 
     for frame_no in itertools.count():


### PR DESCRIPTION
See https://github.com/mikeboers/PyAV/issues/242 for the description of this issue.