### PR TITLE
Add `nd2reader` as a reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ PIMS is based on readers by:
    reads and writes many formats)
 * [moviepy](http://zulko.github.io/moviepy) (a Python module that supports
    video editing)
+* [nd2reader](https://github.com/rbnvrw/nd2reader) (a Pure Python module for reading Nikon NIS Elements ND2 images and metadata)
 
 Examples & Documentation
 ------------------------

--- a/pims/api.py
+++ b/pims/api.py
@@ -110,19 +110,19 @@ except (ImportError, IOError):
 
 try:
     from pims_nd2 import ND2_Reader as ND2Reader_SDK
+
+    class ND2_Reader(ND2Reader_SDK):
+        class_priority = 0
+
+        def __init__(self, *args, **kwargs):
+            warn("'ND2_Reader' has been renamed to 'ND2Reader_SDK' and will be"
+                 "removed in future pims versions. "
+                 "Please use the new name, or try out the pure-Python one named "
+                 "`ND2Reader`.")
+            super(ND2_Reader, self).__init__(*args, **kwargs)
 except ImportError:
     ND2Reader_SDK = not_available("pims_nd2")
-
-
-class ND2_Reader(ND2Reader_SDK):
-    class_priority = 0
-    def __init__(self, *args, **kwargs):
-        warn("'ND2_Reader' has been renamed to 'ND2Reader_SDK' and will be"
-             "removed in future pims versions. "
-             "Please use the new name, or try out the pure-Python one named "
-             "`ND2Reader`.")
-        super(ND2_Reader, self).__init__(*args, **kwargs)
-
+    ND2_Reader = not_available("pims_nd2")
 
 try:
     from nd2reader import ND2Reader

--- a/pims/api.py
+++ b/pims/api.py
@@ -113,6 +113,10 @@ try:
 except ImportError:
     ND2_Reader = not_available("pims_nd2")
 
+try:
+    from nd2reader import ND2Reader
+except ImportError:
+    ND2Reader = not_available("nd2reader")
 
 def open(sequence, **kwargs):
     """Read a filename, list of filenames, or directory of image files into an


### PR DESCRIPTION
[nd2reader](https://github.com/rbnvrw/nd2reader) is a pure-Python package that reads images produced by Nikon NIS Elements 4.0+ microscopes.

Compared to [pims_nd2](https://github.com/soft-matter/pims_nd2), this reader offers some advantages:
- It is not dependent on the Nikon `ND2SDK`, which means the code is fully open-source and can be adapted by anyone.
- It is fully written in Python and does not require any (compiled) platform specific packages
- It can read more metadata than the `ND2SDK` implementation, because the file format has been fully reverse-engineered. For example ROIs are supported.
- The code is (partially) unit tested via CI (Travis) and the code quality is also monitored via CI (Code Climate)
- There is [extensive documentation](http://www.lighthacking.nl/nd2reader/) available

The disadvantages of this package compared to `pims_nd2`are the fact that it can be slightly slower because it is written in Python and that it is not supported by Nikon.

I believe this reader would make a useful addition to the pims project. I will be actively maintaining it, adding new features, fixing bug reports and processing pull requests.