### PR TITLE
FIX: do not use both `with_metaclass` and `__metaclass__`

### DIFF
--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -19,7 +19,6 @@ class FramesStream(with_metaclass(ABCMeta, object)):
 
     Does not support slicing.
     """
-    __metaclass__ = ABCMeta
 
     @abstractmethod
     def __iter__(self):


### PR DESCRIPTION
See https://github.com/benjaminp/six/issues/210

closes #276 

This fixes a show-stopping 'can not import' bug on 2.7, we probably should do an emergency micro release with this patch.