### PR TITLE
Fix imread() imports

### DIFF
--- a/pims/image_reader.py
+++ b/pims/image_reader.py
@@ -9,22 +9,19 @@ from pims.frame import Frame
 # If scikit-image is not available, use matplotlib (with a warning) instead.
 import warnings
 try:
-    from sklearn.io import imread
-except (ImportError, ModuleNotFoundError):
+    from skimage.io import imread
+except ImportError:
     try:
         from matplotlib.pyplot import imread
         # imread() works differently between scikit-image and matplotlib.
         # We don't require users to have scikit-image, 
         # but if we fall back to matplotlib, make sure the user 
         # is aware of the consequences.
-        skimage_preferred = "pim prefers to read images using scikit-image, but you do not appear to have scikit-image installed. " \
-                            "pim will use matplotlib instead. Note that matplotlib reads pixel values as floats (0-1), not integers (0-255). " \
-                            "\n\n" \
-                            "This might break your script." \
-                            "\n\n" \
-                            "(To ignore this warning, include the line \"warnings.simplefilter(\"ignore\", RuntimeWarning)\" in your script.)"
+        skimage_preferred = "pim's image_reader.py could not find scikit-image. Falling back to matplotlib's imread(), which uses floats instead of integers. This may break your scripts." \
+                "\n" \
+                "(To ignore this warning, include the line \"warnings.simplefilter(\"ignore\", RuntimeWarning)\" in your script.)"
         warnings.warn(RuntimeWarning(skimage_preferred))
-    except (ImportError, ModuleNotFoundError):
+    except ImportError:
         imread = None
 
 

--- a/pims/image_reader.py
+++ b/pims/image_reader.py
@@ -28,8 +28,8 @@ except ImportError:
 class ImageReader(FramesSequence):
     """Reads a single image into a length-1 reader.
 
-    Simple wrapper around skimage.io.imread or matplotlib.pyplot.imread or
-    scipy.ndimage.imread, in that priority order."""
+    Simple wrapper around skimage.io.imread or matplotlib.pyplot.imread,
+    in that priority order."""
     @classmethod
     def class_exts(cls):
         return {'png', 'jpg', 'jpeg', 'gif', 'bmp', 'ico'}
@@ -40,7 +40,7 @@ class ImageReader(FramesSequence):
         if imread is None:
             raise ImportError("One of the following packages are required for "
                               "using the ImageReader: "
-                              "scipy, matplotlib or scikit-image.")
+                              "matplotlib or scikit-image.")
 
         self._data = imread(filename, **kwargs)
 
@@ -62,8 +62,8 @@ class ImageReader(FramesSequence):
 class ImageReaderND(FramesSequenceND):
     """Reads a single image into a dimension-aware reader.
 
-    Simple wrapper around skimage.io.imread or matplotlib.pyplot.imread or
-    scipy.ndimage.imread, in that priority order."""
+    Simple wrapper around skimage.io.imread or matplotlib.pyplot.imread,
+    in that priority order."""
     @classmethod
     def class_exts(cls):
         return {'png', 'jpg', 'jpeg', 'gif', 'bmp', 'ico'}
@@ -74,7 +74,7 @@ class ImageReaderND(FramesSequenceND):
         if imread is None:
             raise ImportError("One of the following packages are required for "
                               "using the ImageReaderND: "
-                              "scipy, matplotlib or scikit-image.")
+                              "matplotlib or scikit-image.")
         super(ImageReaderND, self).__init__()
 
         self._data = Frame(imread(filename, **kwargs), frame_no=0)

--- a/pims/image_reader.py
+++ b/pims/image_reader.py
@@ -6,18 +6,26 @@ import numpy as np
 from pims.base_frames import FramesSequence, FramesSequenceND
 from pims.frame import Frame
 
-# skimage.io.plugin_order() gives a nice hierarchy of implementations of imread.
-# If skimage is not available, go down our own hard-coded hierarchy.
+# If scikit-image is not available, use matplotlib (with a warning) instead.
+import warnings
 try:
-    from skimage.io import imread
-except ImportError:
+    from sklearn.io import imread
+except (ImportError, ModuleNotFoundError):
     try:
         from matplotlib.pyplot import imread
-    except ImportError:
-        try:
-            from scipy.ndimage import imread
-        except:
-            imread = None
+        # imread() works differently between scikit-image and matplotlib.
+        # We don't require users to have scikit-image, 
+        # but if we fall back to matplotlib, make sure the user 
+        # is aware of the consequences.
+        skimage_preferred = "pim prefers to read images using scikit-image, but you do not appear to have scikit-image installed. " \
+                            "pim will use matplotlib instead. Note that matplotlib reads pixel values as floats (0-1), not integers (0-255). " \
+                            "\n\n" \
+                            "This might break your script." \
+                            "\n\n" \
+                            "(To ignore this warning, include the line \"warnings.simplefilter(\"ignore\", RuntimeWarning)\" in your script.)"
+        warnings.warn(RuntimeWarning(skimage_preferred))
+    except (ImportError, ModuleNotFoundError):
+        imread = None
 
 
 class ImageReader(FramesSequence):

--- a/pims/image_reader.py
+++ b/pims/image_reader.py
@@ -17,10 +17,14 @@ except ImportError:
         # We don't require users to have scikit-image, 
         # but if we fall back to matplotlib, make sure the user 
         # is aware of the consequences.
-        skimage_preferred = "pim's image_reader.py could not find scikit-image. Falling back to matplotlib's imread(), which uses floats instead of integers. This may break your scripts." \
+        ski_preferred = "PIMS image_reader.py could not find scikit-image. " \
+                + "Falling back to matplotlib's imread(), which uses floats " \
+                + "instead of integers. This may break your scripts. " \
                 "\n" \
-                "(To ignore this warning, include the line \"warnings.simplefilter(\"ignore\", RuntimeWarning)\" in your script.)"
-        warnings.warn(RuntimeWarning(skimage_preferred))
+                "(To ignore this warning, include the line " \ 
+                + "\"warnings.simplefilter(\"ignore\", RuntimeWarning)\" " \
+                + "in your script.)"
+        warnings.warn(RuntimeWarning(ski_preferred))
     except ImportError:
         imread = None
 

--- a/pims/image_reader.py
+++ b/pims/image_reader.py
@@ -17,13 +17,12 @@ except ImportError:
         # We don't require users to have scikit-image, 
         # but if we fall back to matplotlib, make sure the user 
         # is aware of the consequences.
-        ski_preferred = "PIMS image_reader.py could not find scikit-image. " \
-                + "Falling back to matplotlib's imread(), which uses floats " \
-                + "instead of integers. This may break your scripts. " \
-                "\n" \
-                "(To ignore this warning, include the line " \ 
-                + "\"warnings.simplefilter(\"ignore\", RuntimeWarning)\" " \
-                + "in your script.)"
+        ski_preferred = ("PIMS image_reader.py could not find scikit-image. "
+                 "Falling back to matplotlib's imread(), which uses floats "
+                 "instead of integers. This may break your scripts. \n"
+                 "(To ignore this warning, include the line "
+                 '"warnings.simplefilter("ignore", RuntimeWarning)" '
+                 "in your script.)")
         warnings.warn(RuntimeWarning(ski_preferred))
     except ImportError:
         imread = None


### PR DESCRIPTION
This fixes issue #280, with the current approach of three different imread() functions being imported, two of which work differently and one of which is deprecated.

The new behavior is:
* Try to find scikit-image and use `skimage.io.imread()` to read images. This has the preferred imread() functionality.
* If scikit-image is not found, use `matplotlib.pyplot.imread()` and warn the user that this function will import pixel values as floats and not integers. Also tell the user how to turn off this warning message if they get sick of seeing it.
* Remove the attempt to import `imread()` from `scipy.ndimage`, since it is deprecated (also see output in [this gist](https://gist.github.com/charlesreid1/2087ab15d26a9eb07a13f896b2d7d626))
