### PR TITLE
BUG: RGBA movie export

### DIFF
--- a/pims/display.py
+++ b/pims/display.py
@@ -149,6 +149,8 @@ def export_pyav(sequence, filename, rate=30, bitrate=None,
                                                       export_rate)
                 stream.bit_rate = int(bitrate)
 
+	# Ensure correct memory layout
+        img = img.astype(img.dtype, order='C', copy=False)
         frame = av.VideoFrame.from_ndarray(img, format=str('rgb24'))
         packet = stream.encode(frame)
         if packet is not None:
@@ -483,9 +485,10 @@ def _to_rgb_uint8(image, autoscale):
         color_axis = shape.index(3)
         image = np.rollaxis(image, color_axis, 3)
     elif image.ndim == 3 and shape.count(4) == 1:
-        # This is an RGBA image. Drop the A values.
+        # This is an RGBA image. Ensure that the color axis is axis 2, and 
+        # drop the A values.
         color_axis = shape.index(4)
-        image = np.rollaxis(image, color_axis, 4)[:, :, :3]
+        image = np.rollaxis(image, color_axis, 3)[:, :, :3]
     elif ndim == 2:
         # Expand into color to satisfy moviepy's expectation
         image = np.repeat(image[:, :, np.newaxis], 3, axis=2)

--- a/pims/display.py
+++ b/pims/display.py
@@ -93,7 +93,6 @@ def export_pyav(sequence, filename, rate=30, bitrate=None,
     export_rate = _normalize_framerate(rate, *rate_range)
     sequence = CachedFrameGenerator(sequence, rate, autoscale)
 
-
     # pyav is picky with unicode strings
     codec = str(codec)
     if format is not None:
@@ -149,7 +148,7 @@ def export_pyav(sequence, filename, rate=30, bitrate=None,
                                                       export_rate)
                 stream.bit_rate = int(bitrate)
 
-	# Ensure correct memory layout
+        # Ensure correct memory layout
         img = img.astype(img.dtype, order='C', copy=False)
         frame = av.VideoFrame.from_ndarray(img, format=str('rgb24'))
         packet = stream.encode(frame)
@@ -324,12 +323,14 @@ def export_moviepy(sequence, filename, rate=30, bitrate=None, width=None,
     clip.write_videofile(filename, export_rate, codec, bitrate, audio=False,
                          verbose=verbose, ffmpeg_params=ffmpeg_params)
 
+
 if av is not None:
     export = export_pyav
 elif VideoClip is not None:
     export = export_moviepy
 else:
     export = None
+
 
 def repr_video(fname, mimetype):
     """Load the video in the file `fname`, with given mimetype,
@@ -427,7 +428,7 @@ def scrollable_stack(sequence, width=512, normed=True):
 
 
 def _as_png(arr, width, normed=True):
-    "Create a PNG image buffer from an array."
+    """Create a PNG image buffer from an array."""
     try:
         from PIL import Image
     except ImportError:
@@ -499,7 +500,7 @@ def _to_rgb_uint8(image, autoscale):
 
 
 def _estimate_bitrate(shape, frame_rate):
-    "Return a bitrate that will guarantee lossless video."
+    """Return a bitrate that will guarantee lossless video."""
     # Total Pixels x 8 bits x 3 channels x FPS
     return shape[0] * shape[1] * 8 * 3 * frame_rate
 

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -14,6 +14,7 @@ from nose.tools import assert_true, assert_equal, assert_less
 from .test_common import _skip_if_no_MoviePy, _skip_if_no_PyAV, path
 
 import unittest
+
 try:
     import matplotlib as mpl
     import matplotlib.pyplot as plt
@@ -21,16 +22,18 @@ except ImportError:
     mpl = None
     plt = None
 
+
 def _skip_if_no_mpl():
     if plt is None:
         raise nose.SkipTest('Matplotlib not installed. Skipping.')
+
 
 class TestPlotToFrame(unittest.TestCase):
     def setUp(self):
         _skip_if_no_mpl()
         plt.switch_backend('Agg')  # does not plot to screen
-        x = np.linspace(0, 2*np.pi, 100)
-        t = np.linspace(0, 2*np.pi, 10)
+        x = np.linspace(0, 2 * np.pi, 100)
+        t = np.linspace(0, 2 * np.pi, 10)
         y = np.sin(x[np.newaxis, :] - t[:, np.newaxis])
 
         self.figures = []
@@ -78,10 +81,10 @@ class TestPlotToFrame(unittest.TestCase):
         assert_less(plot_to_frame(fig, bbox_inches='tight').shape[:2], (384, 512))
         assert_equal(plot_to_frame(fig).shape[:2], (384, 512))
 
-        fig.set_tight_layout(True)   # default to tight
+        fig.set_tight_layout(True)  # default to tight
         assert_less(plot_to_frame(fig).shape[:2], (384, 512))
         assert_equal(plot_to_frame(fig, bbox_inches='standard').shape[:2],
-                    (384, 512))
+                     (384, 512))
         assert_less(plot_to_frame(fig).shape[:2], (384, 512))
 
     def test_plots_tight(self):
@@ -121,7 +124,7 @@ class ExportCommon(object):
                                           ).astype(np.uint8)
         self.sequence_rgba = np.random.randint(0, 255,
                                                size=(self.expected_len,) +
-                                               self.expected_shape_rgba,
+                                                    self.expected_shape_rgba,
                                                ).astype(np.uint8)
         self.tempfile = 'tempvideo.avi'  # avi containers support most codecs
 

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -179,14 +179,21 @@ class ExportCommon(object):
             for a, b in zip(sequence_rgba_stripped, reader):
                 assert_array_equal(a, b)
 
-    def test_rgba_memorder(self):
-        """RGBA with alpha removed has different memory order."""
-        self.export_func(self.sequence_rgba[:, :, :, :3], self.tempfile,
-                         codec='libx264')
-
     def test_rawvideo_export(self):
         """Exported frames must equal the input exactly"""
         self.export_func(self.sequence, self.tempfile, codec='rawvideo',
+                         pixel_format='bgr24')
+        with pims.open(self.tempfile) as reader:
+            assert_equal(len(reader), self.expected_len)
+            assert_equal(reader.frame_shape, self.expected_shape)
+            for a, b in zip(self.sequence, reader):
+                assert_array_equal(a, b)
+
+    def test_rgb_memorder(self):
+        """Fortran memory order must be converted."""
+        self.export_func(self.sequence.astype(self.sequence.dtype,
+                                              order='F'),
+                         self.tempfile, codec='rawvideo',
                          pixel_format='bgr24')
         with pims.open(self.tempfile) as reader:
             assert_equal(len(reader), self.expected_len)

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -192,15 +192,21 @@ class ExportCommon(object):
                 assert_array_equal(a, b)
 
 
-class TestExportMoviePy(unittest.TestCase, ExportCommon):
+class TestExportMoviePy(ExportCommon, unittest.TestCase):
     def setUp(self):
         _skip_if_no_MoviePy()
         self.export_func = functools.partial(export_moviepy, verbose=False)
         ExportCommon.setUp(self)
 
+    def tearDown(self):
+        super(TestExportMoviePy, self).tearDown()
 
-class TestExportPyAV(unittest.TestCase, ExportCommon):
+
+class TestExportPyAV(ExportCommon, unittest.TestCase):
     def setUp(self):
         _skip_if_no_PyAV()
         self.export_func = export_pyav
         ExportCommon.setUp(self)
+
+    def tearDown(self):
+        super(TestExportPyAV, self).tearDown()


### PR DESCRIPTION
The code to remove the alpha channel before exporting with PyAV or MoviePy had some mistakes. Furthermore, NumPy tends to store RGBA sequence data in a different memory order than RGB, causing problems.

This also makes sure that the exported movie is cleaned up at the end of each test.