### PR TITLE
Fixed problem with PyAV 0.4.0 and further code for video reading

### DIFF
--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -132,7 +132,7 @@ class PyAVReaderTimed(FramesSequence):
         self._cache = [None] * cache_size
         self._fast_forward_thresh = fast_forward_thresh
 
-        demuxer = self._container.demux(streams=self._stream)
+        demuxer = self._container.demux(self._stream)
 
         # obtain first frame to get first time point
         # also tests for the presence of timestamps
@@ -150,7 +150,7 @@ class PyAVReaderTimed(FramesSequence):
         return int(self._duration * self._frame_rate)
 
     def _reset_demuxer(self):
-        demuxer = self._container.demux(streams=self._stream)
+        demuxer = self._container.demux(self._stream)
         self._frame_generator = _gen_frames(demuxer, self._stream.time_base,
                                             self._frame_rate, self._first_pts)
 


### PR DESCRIPTION
Should fix this: https://github.com/soft-matter/pims/issues/296

Hello, I'm new to both these projects (PIMS and PyAV), so if I did something wrong, I'm sorry.

Basically I traced the problem to that code, where it seems that the get(self, *args, **kwargs) function in av/container/streams.pyx in PyAV can receive either:
- A stream, in which case the stream itself is returned
- An index, in which case the nth "stream" from their internal list of streams is returned (member _streams)
- A dictionary, in which case the key must be one of the members of that class (_streams, video, audio, subtitles, data, other) and the value must be a list of indexes (or something else, in which case it's considered it's an int, and converted to a list)

What PIMS (this library) sends is a dictionary, with key _streams and value a Stream, so it tries to call
self._streams[StreamObject], which isn't an index and it fails.

Since that StreamObject is in the _stream list (I guess they should check that), it can be passed simply (without keyword argument, in which case it's treated as a dict in their code), so the 

``
elif isinstance(x, Stream):
      selection.append(x)
``

is taken, and the Stream is simply returned.

Sorry for the big story and if there's a better fix, do that instead :)

Mihai