### PR TITLE
Remove as_grey from docstrings

### DIFF
--- a/pims/ffmpeg_reader.py
+++ b/pims/ffmpeg_reader.py
@@ -32,13 +32,6 @@
 #
 # Files heavily edited by PIMS contributors
 # January 2014
-
-## Name (and locatio if needed) of the FFMPEG binary. It will be
-## "ffmpeg" on linux, certainly "ffmpeg.exe" on windows, else any path.
-## If not provided (None), the system will look for the right version
-## automatically each time you launch moviepy.
-## If you run this script file it will check that the
-## path to the ffmpeg binary (FFMPEG_BINARY)
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
@@ -73,6 +66,8 @@ def try_ffmpeg(FFMPEG_BINARY):
         return True
 
 
+# Name (and location if needed) of the FFMPEG binary. It will be
+# "ffmpeg" on linux, certainly "ffmpeg.exe" on windows, else any path.
 FFMPEG_BINARY_SUGGESTIONS = ['ffmpeg', 'ffmpeg.exe']
 
 FFMPEG_BINARY = None

--- a/pims/ffmpeg_reader.py
+++ b/pims/ffmpeg_reader.py
@@ -99,14 +99,13 @@ class FFmpegVideoReader(FramesSequence):
     Parameters
     ----------
     filename : string
-    process_func : function, optional
-        callable with signalture `proc_img = process_func(img)`,
-        which will be applied to the data from each frame
-    dtype : numpy datatype, optional
-        Image arrays will be converted to this datatype.
-    as_grey : boolean, optional
-        Convert color images to greyscale. False by default.
-        May not be used in conjection with process_func.
+    pix_fmt : string, optional
+        Expected number of color channels. Either 'rgb24' or 'rgba'.
+        Defaults to 'rgba'.
+    use_cache : boolean, optional
+        Saves time if the file was previously opened. Defaults to True.
+        Set to False if the file may have changed since it was
+        last read.
 
     Examples
     --------

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -44,14 +44,6 @@ class ImageSequence(FramesSequence):
         which will ignore extraneous files or a list of files to open
         in the order they should be loaded. When a path to a zipfile is
         specified, all files in the zipfile will be loaded.
-    process_func : function, optional
-        callable with signalture `proc_img = process_func(img)`,
-        which will be applied to the data from each frame
-    dtype : numpy datatype, optional
-        Image arrays will be converted to this datatype.
-    as_grey : boolean, optional
-        Convert color images to greyscale. False by default.
-        May not be used in conjection with process_func.
     plugin : string
         Passed on to skimage.io.imread if scikit-image is available.
         If scikit-image is not available, this will be ignored and a warning
@@ -365,13 +357,6 @@ class ImageSequenceND(FramesSequenceND, ImageSequence):
         specified, all files in the zipfile will be loaded. The filenames
         should contain the indices of T, Z and C, preceded by a axis
         identifier such as: 'file_t001c05z32'.
-    process_func : function, optional
-        callable with signature `proc_img = process_func(img)`,
-        which will be applied to the data from each frame.
-    dtype : numpy datatype, optional
-        Image arrays will be converted to this datatype.
-    as_grey : boolean, optional
-        Not implemented for 3D images.
     plugin : string, optional
         Passed on to skimage.io.imread if scikit-image is available.
         If scikit-image is not available, this will be ignored and a warning


### PR DESCRIPTION
This follows up on #250 by updating docstrings. It also corrects the kwargs listing for `FFmpegVideoReader`.