### PR TITLE
Travisfixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - python: "2.7"
       env: DEPS="numpy=1.8* slicerator tifffile" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1 moviepy imageio imageio-ffmpeg" BUILD_DOCS=false
+      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1 moviepy imageio==2.4" BUILD_DOCS=false
     - python: "3.6"
       env: DEPS="numpy slicerator tifffile" BUILD_DOCS=false
     - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - python: "2.7"
       env: DEPS="numpy=1.8* slicerator tifffile" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1 moviepy imageio==2.4" BUILD_DOCS=false
+      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1 moviepy" DEPSPIP="imageio==2.4" BUILD_DOCS=false
     - python: "3.6"
       env: DEPS="numpy slicerator tifffile" BUILD_DOCS=false
     - python: "3.6"
@@ -20,11 +20,11 @@ install:
   - conda create -n testenv --yes $DEPS nose python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # only install pip if there are pip dependencies
-  # - |
-  #   if [ -n "$DEPSPIP" ]; then
-  #       conda install -n testenv --yes pip
-  #       pip install $DEPSPIP
-  #   fi
+  - |
+    if [ -n "$DEPSPIP" ]; then
+        conda install -n testenv --yes pip
+        pip install $DEPSPIP
+    fi
   - python setup.py build_ext install
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ matrix:
     - python: "2.7"
       env: DEPS="numpy=1.8* slicerator tifffile" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1 moviepy" DEPSPIP="imageio==2.4" BUILD_DOCS=false
+      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1 moviepy imageio==2.4.1" BUILD_DOCS=false
     - python: "3.6"
       env: DEPS="numpy slicerator tifffile" BUILD_DOCS=false
     - python: "3.6"
@@ -20,11 +20,11 @@ install:
   - conda create -n testenv --yes $DEPS nose python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # only install pip if there are pip dependencies
-  - |
-    if [ -n "$DEPSPIP" ]; then
-        conda install -n testenv --yes pip
-        pip install $DEPSPIP
-    fi
+  # - |
+  #   if [ -n "$DEPSPIP" ]; then
+  #       conda install -n testenv --yes pip
+  #       pip install $DEPSPIP
+  #   fi
   - python setup.py build_ext install
 
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ matrix:
     - python: "2.7"
       env: DEPS="numpy=1.8* slicerator tifffile" BUILD_DOCS=false
     - python: "2.7"
-      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1" DEPSPIP="moviepy imageio" BUILD_DOCS=false
+      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1 moviepy imageio imageio-ffmpeg" BUILD_DOCS=false
     - python: "3.6"
       env: DEPS="numpy slicerator tifffile" BUILD_DOCS=false
     - python: "3.6"
-      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av tifffile libtiff jpype1 ipython sphinx sphinx_rtd_theme numpydoc" DEPSPIP="moviepy imageio" BUILD_DOCS=true
+      env: DEPS="numpy slicerator scipy pillow matplotlib scikit-image jinja2 av tifffile libtiff jpype1 ipython sphinx sphinx_rtd_theme numpydoc moviepy imageio imageio-ffmpeg" BUILD_DOCS=true
 
 install:
   - conda update --yes conda
@@ -20,20 +20,20 @@ install:
   - conda create -n testenv --yes $DEPS nose python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # only install pip if there are pip dependencies
-  - |
-    if [ -n "$DEPSPIP" ]; then
-        conda install -n testenv --yes pip
-        pip install $DEPSPIP
-    fi
+  # - |
+  #   if [ -n "$DEPSPIP" ]; then
+  #       conda install -n testenv --yes pip
+  #       pip install $DEPSPIP
+  #   fi
   - python setup.py build_ext install
 
 
 before_install:
   - if [ ${TRAVIS_PYTHON_VERSION:0:1} == "2" ];
     then
-        wget http://repo.continuum.io/miniconda/Miniconda-3.7.3-Linux-x86_64.sh -O miniconda.sh;
+        wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh;
     else
-        wget http://repo.continuum.io/miniconda/Miniconda3-3.7.3-Linux-x86_64.sh -O miniconda.sh;
+        wget http://repo.continuum.io/miniconda/Miniconda3-latest-Linux-x86_64.sh -O miniconda.sh;
     fi
   - chmod +x miniconda.sh
   - ./miniconda.sh -b -p /home/travis/mc

--- a/pims/display.py
+++ b/pims/display.py
@@ -32,6 +32,9 @@ try:
         from moviepy.editor import VideoClip
 except ImportError:
     VideoClip = None
+except RuntimeError:
+    # there is an incompatibility between moviepy 2.3.5 and imageio >= 2.5.0
+    VideoClip = None
 
 
 def export_pyav(sequence, filename, rate=30, bitrate=None,

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -21,8 +21,10 @@ from pims.utils.sort import natural_keys
 
 # skimage.io.plugin_order() gives a nice hierarchy of implementations of imread.
 # If skimage is not available, go down our own hard-coded hierarchy.
+has_skimage = False
 try:
     from skimage.io import imread
+    has_skimage = True
 except ImportError:
     try:
         from matplotlib.pyplot import imread
@@ -69,9 +71,7 @@ class ImageSequence(FramesSequence):
     >>> frame_shape = video.frame_shape # Pixel dimensions of video
     """
     def __init__(self, path_spec, plugin=None):
-        try:
-            import skimage
-        except ImportError:
+        if not has_skimage:
             if plugin is not None:
                 warn("A plugin was specified but ignored. Plugins can only "
                      "be specified if scikit-image is available. Instead, "

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -35,6 +35,10 @@ class ImageIOReader(FramesSequence):
         self.filename = filename
         self._len = self.reader.get_length()
 
+        # fallback to count_frames, for newer imageio versions
+        if self._len == float("inf"):
+            self._len = self.reader.count_frames()
+
         first_frame = self.get_frame(0)
         self._shape = first_frame.shape
         self._dtype = first_frame.dtype

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -3,11 +3,16 @@ from __future__ import (absolute_import, division, print_function,
 
 import six
 
+from distutils.version import LooseVersion
+
 from pims.base_frames import FramesSequence
 from pims.frame import Frame
 
 try:
     import imageio
+    # from imageio 2.5, imageio_ffmpeg is needed as well
+    if LooseVersion(imageio.__version__) >= LooseVersion("2.5.0"):
+        import imageio_ffmpeg
 except ImportError:
     imageio = None
 
@@ -30,7 +35,8 @@ class ImageIOReader(FramesSequence):
 
     def __init__(self, filename, **kwargs):
         if imageio is None:
-            raise ImportError('The ImageIOReader requires imageio to work.')
+            raise ImportError('The ImageIOReader requires imageio and '
+                              '(for imageio >= 2.5) imageio-ffmpeg to work.')
         self.reader = imageio.get_reader(filename, **kwargs)
         self.filename = filename
         self._len = self.reader.get_length()

--- a/pims/moviepy_reader.py
+++ b/pims/moviepy_reader.py
@@ -13,6 +13,9 @@ try:
         from moviepy.editor import VideoFileClip
 except ImportError:
     VideoFileClip = None
+except RuntimeError:
+    # there is an incompatibility between moviepy 2.3.5 and imageio >= 2.5.0
+    VideoFileClip = None
 
 
 def available():


### PR DESCRIPTION
This fixes two issues related to skimage and imagio changes:

 - a certain combination of skimage and numpy raises an `ImportError` on `import skimage.io` and not on `import skimage`. This makes the logic in that area a bit more robust
 - Newer imageIO versions return Inf on `reader.get_length`, you need to call `reader.count_frames` to get the length. This solves the `TypeErrors` encountered in https://github.com/soft-matter/pims/pull/317