### PR TITLE
Fix PyAVReaderIndexed for videos with audio.

### DIFF
--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -308,10 +308,10 @@ class PyAVReaderIndexed(FramesSequence):
         return {'mov', 'avi',
                 'mp4'} | super(PyAVReaderIndexed, cls).class_exts()
 
-    def __init__(self, file, toc=None):
+    def __init__(self, file, toc=None, format=None):
         self.file = file
 
-        container = av.open(self.file)
+        container = av.open(self.file, format=format)
 
         # Build a toc
         if toc is None:

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -337,7 +337,7 @@ class PyAVReaderIndexed(FramesSequence):
         self._load_fresh_file()
 
     def _load_fresh_file(self):
-        if isinstance(self.file, io.BytesIO):
+        if hasattr(self.file, 'seek'):
             self.file.seek(0)
         self._container_iter = av.open(self.file, format=self.format).demux()
         self._current_packet = _next_video_packet(self._container_iter)

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -362,10 +362,7 @@ class PyAVReaderIndexed(FramesSequence):
         else:
             loc = j - self._toc[packet_no - 1]
         frame = self._current_packet[loc]  # av.VideoFrame
-        if frame.index != j:
-            raise AssertionError(
-                "Seeking failed to obtain the correct frame. ({} != {})"
-                .format(frame.index, j))
+
         return Frame(frame.to_ndarray(format='rgb24'), frame_no=j)
 
     def _seek_packet(self, packet_no):

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -111,9 +111,10 @@ class PyAVReaderTimed(FramesSequence):
         return {'mov', 'avi', 'mp4'} | super(PyAVReaderTimed, cls).class_exts()
 
     def __init__(self, file, cache_size=16, fast_forward_thresh=32,
-                 stream_index=0):
+                 stream_index=0, format=None):
         self.file = file
-        self._container = av.open(self.file)
+        self.format = format
+        self._container = av.open(self.file, format=self.format)
 
         if len(self._container.streams.video) == 0:
             raise IOError("No valid video stream found in {}".format(file))
@@ -310,8 +311,9 @@ class PyAVReaderIndexed(FramesSequence):
 
     def __init__(self, file, toc=None, format=None):
         self.file = file
+        self.format = format
 
-        container = av.open(self.file, format=format)
+        container = av.open(self.file, format=self.format)
 
         # Build a toc
         if toc is None:
@@ -334,7 +336,7 @@ class PyAVReaderIndexed(FramesSequence):
         self._load_fresh_file()
 
     def _load_fresh_file(self):
-        self._container_iter = av.open(self.file).demux()
+        self._container_iter = av.open(self.file, format=self.format).demux()
         self._current_packet = _next_video_packet(self._container_iter)
         self._packet_cursor = 0
         self._frame_cursor = 0

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+import io
 import six
 import re
 
@@ -336,6 +337,8 @@ class PyAVReaderIndexed(FramesSequence):
         self._load_fresh_file()
 
     def _load_fresh_file(self):
+        if isinstance(self.file, io.BytesIO):
+            self.file.seek(0)
         self._container_iter = av.open(self.file, format=self.format).demux()
         self._current_packet = _next_video_packet(self._container_iter)
         self._packet_cursor = 0

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -351,8 +351,9 @@ class PyAVReaderIndexed(FramesSequence):
             loc = j - self._toc[packet_no - 1]
         frame = self._current_packet[loc]  # av.VideoFrame
         if frame.index != j:
-            raise AssertionError("Seeking failed to obtain the correct frame."
-                                 f" ({frame.index} != {j})")
+            raise AssertionError(
+                "Seeking failed to obtain the correct frame. ({} != {})"
+                .format(frame.index, j))
         return Frame(frame.to_ndarray(format='rgb24'), frame_no=j)
 
     def _seek_packet(self, packet_no):

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -45,7 +45,7 @@ class WrapPyAvFrame(object):
 
     def to_frame(self):
         if self.arr is None:
-            self.arr = Frame(_to_nd_array(self.frame), frame_no=self.frame_no,
+            self.arr = Frame(self.frame.to_ndarray(), frame_no=self.frame_no,
                              metadata=self.metadata)
         return self.arr
 
@@ -355,8 +355,7 @@ class PyAVReaderIndexed(FramesSequence):
         frame = self._current_packet[loc]  # av.VideoFrame
         if frame.index != j:
             raise AssertionError("Seeking failed to obtain the correct frame.")
-        result = _to_nd_array(frame)
-        return Frame(result, frame_no=j)
+        return Frame(frame.to_ndarray(), frame_no=j)
 
     def _seek_packet(self, packet_no):
         """Advance through the container generator until we get the packet

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -110,13 +110,13 @@ class PyAVReaderTimed(FramesSequence):
     def class_exts(cls):
         return {'mov', 'avi', 'mp4'} | super(PyAVReaderTimed, cls).class_exts()
 
-    def __init__(self, filename, cache_size=16, fast_forward_thresh=32,
+    def __init__(self, file, cache_size=16, fast_forward_thresh=32,
                  stream_index=0):
-        self.filename = str(filename)
-        self._container = av.open(self.filename)
+        self.file = file
+        self._container = av.open(self.file)
 
         if len(self._container.streams.video) == 0:
-            raise IOError("No valid video stream found in {}".format(filename))
+            raise IOError("No valid video stream found in {}".format(file))
 
         self._stream = self._container.streams.video[stream_index]
 
@@ -127,7 +127,7 @@ class PyAVReaderTimed(FramesSequence):
 
         self._frame_rate = self._stream.average_rate
         if self.duration <= 0 or len(self) <= 0:
-            raise IOError("Video stream {} in {} has zero length.".format(stream_index, filename))
+            raise IOError("Video stream {} in {} has zero length.".format(stream_index, file))
 
         self._cache = [None] * cache_size
         self._fast_forward_thresh = fast_forward_thresh
@@ -271,7 +271,7 @@ Frame Shape: {frame_shape!r}
            duration=self.duration,
            frame_rate=self.frame_rate,
            count=len(self),
-           filename=self.filename)
+           filename=self.file)
 
 
 class PyAVReaderIndexed(FramesSequence):
@@ -308,13 +308,13 @@ class PyAVReaderIndexed(FramesSequence):
         return {'mov', 'avi',
                 'mp4'} | super(PyAVReaderIndexed, cls).class_exts()
 
-    def __init__(self, filename):
-        self.filename = str(filename)
+    def __init__(self, file):
+        self.file = file
         self._initialize()
 
     def _initialize(self):
         "Scan through and tabulate contents to enable random access."
-        container = av.open(self.filename)
+        container = av.open(self.file)
 
         # Build a toc
         self._toc = np.cumsum([len(packet.decode())
@@ -332,7 +332,7 @@ class PyAVReaderIndexed(FramesSequence):
         self._load_fresh_file()
 
     def _load_fresh_file(self):
-        self._container_iter = av.open(self.filename).demux()
+        self._container_iter = av.open(self.file).demux()
         self._current_packet = _next_video_packet(self._container_iter)
         self._packet_cursor = 0
         self._frame_cursor = 0
@@ -388,4 +388,4 @@ Length: {count} frames
 Frame Shape: {frame_shape!r}
 """.format(frame_shape=self.frame_shape,
            count=len(self),
-           filename=self.filename)
+           filename=self.file)

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -113,6 +113,8 @@ class PyAVReaderTimed(FramesSequence):
 
     def __init__(self, file, cache_size=16, fast_forward_thresh=32,
                  stream_index=0, format=None):
+        if not hasattr(file, 'read'):
+            file = str(file)
         self.file = file
         self.format = format
         self._container = av.open(self.file, format=self.format)

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -311,6 +311,8 @@ class PyAVReaderIndexed(FramesSequence):
                 'mp4'} | super(PyAVReaderIndexed, cls).class_exts()
 
     def __init__(self, file, toc=None, format=None):
+        if not hasattr(file, 'read'):
+            file = str(file)
         self.file = file
         self.format = format
 

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -310,17 +310,13 @@ class PyAVReaderIndexed(FramesSequence):
 
     def __init__(self, file):
         self.file = file
-        self._initialize()
 
-    def _initialize(self):
-        "Scan through and tabulate contents to enable random access."
         container = av.open(self.file)
 
         # Build a toc
         self._toc = np.cumsum([len(packet.decode())
                                for packet in container.demux()
                                if packet.stream.type == 'video'])
-        print(self._toc)
         self._len = self._toc[-1]
 
         video_stream = [s for s in container.streams if s.type == 'video'][0]


### PR DESCRIPTION
This PR introduces four changes:

1. The built-in PyAV .to_ndarray() function is used instead of a custom one which fixes some data format issues. I also imagine it reduces some overhead since it's a Cython function.
2. Skip non-video packets when indexing/seeking the container. This fixes an issue where reading some video files with an audio stream would cause errors.
3. Add a 'toc' argument to PyAVReaderIndexed so that pre-comptued tables can be passed in.
4. Removed an assertion that j == frame.index. As discussed in https://github.com/mikeboers/PyAV/issues/33, it seems like the index property may not be reliable in some cases. I've encountered files with packets with duplicate "index" values but the correct number of frames overall.