### PR TITLE
Fix Bio-Formats download zips

### DIFF
--- a/download_bioformats_test.py
+++ b/download_bioformats_test.py
@@ -15,19 +15,23 @@ def download_bioformats_tstfiles():
 
     def get_bioformats_file(filename, filepath='', url=''):
         if url == '':
-            url = 'http://www.loci.wisc.edu/files/software/data/' + filename
+            url = 'https://samples.scif.io/' + filename
         fn = os.path.join(filepath, filename)
         urlretrieve(url, fn)
-        with ZipFile(fn) as zf:
-            zf.extractall(filepath)
-        os.remove(fn)
-        if os.path.isfile('readme.txt'):
-            os.remove('readme.txt')
+        try:
+            with ZipFile(fn) as zf:
+                zf.extractall(filepath)
+            os.remove(fn)
+            if os.path.isfile('readme.txt'):
+                os.remove('readme.txt')
+        except:
+            print("Failed to extract {}".format(fn))
+            raise
 
     passing = ['qdna1.zip', 'leica_stack.zip', 'Blend_Final.zip', 'HEART.zip',
                'wtembryo.zip', 'mitosis-test.zip', 'dnasample1.zip',
                '2chZT.zip', 'mouse-kidney.zip', 'MF-2CH-Z-T.zip',
-               '10-31%20E1.zip', 'KEVIN2-3.zip']
+               '10-31_E1.zip', 'KEVIN2-3.zip']
 
     #failing = ['sdub.zip', 'NESb.zip', 'TAABA.zip', 'embryo2.zip', 'dub.zip']
 


### PR DESCRIPTION
The zips used for testing Bio-Formats have been moved
to the scif.io domain. With this change, both 5.7.0
as well as 5.8.2 from gh-301 pass for:

```
nosetests --nologcapture -i bioformats
```