### PR TITLE
FIX: ImageIOReader in pims.api

### DIFF
--- a/pims/api.py
+++ b/pims/api.py
@@ -58,7 +58,7 @@ try:
     else:
         raise ImportError()
 except (ImportError, IOError):
-    MoviePyReader = not_available("ImageIO")
+    ImageIOReader = not_available("ImageIO")
 
 
 try:


### PR DESCRIPTION
This fixes a (presumable) copy&paste error in api.py, so that `ImageIOReader = not_available("ImageIO")` when importing pims.imageio_reader fails.