### PR TITLE
Speed up random access time of PyAVReaderIndexed.

### DIFF
--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -1,17 +1,10 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
-import time
-
-import io
-import six
-import re
 
 import numpy as np
 
 from pims.base_frames import FramesSequence
 from pims.frame import Frame
-
-from warnings import warn
 
 
 try:

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -320,22 +320,22 @@ class PyAVReaderIndexed(FramesSequence):
 
             # Build a toc
             if toc is None:
-                self._packet_lengths = []
-                self._packet_ts = []
+                packet_lengths = []
+                packet_ts = []
                 for packet in container.demux(stream):
                     if packet.stream.type == 'video':
                         decoded = packet.decode()
                         if len(decoded) > 0:
-                            self._packet_lengths.append(len(decoded))
-                            self._packet_ts.append(decoded[0].pts)
+                            packet_lengths.append(len(decoded))
+                            packet_ts.append(decoded[0].pts)
                 self._toc = {
-                    'lengths': self._packet_lengths,
-                    'ts': self._packet_ts,
+                    'lengths': packet_lengths,
+                    'ts': packet_ts,
                 }
             else:
                 self._toc = toc
 
-            self._toc_cumsum = np.cumsum(self._toc['lengths'])
+            self._toc_cumsum = np.cumsum(self.toc['lengths'])
             self._len = self._toc_cumsum[-1]
 
             # PyAV always returns frames in color, and we make that
@@ -391,7 +391,7 @@ class PyAVReaderIndexed(FramesSequence):
     def _seek_packet(self, packet_no):
         """Advance through the container generator until we get the packet
         we want. Store that packet in selfpp._current_packet."""
-        packet_ts = self._packet_ts[packet_no]
+        packet_ts = self.toc['ts'][packet_no]
         # Only seek when needed.
         if packet_no == self._current_packet_no:
             return

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -1,5 +1,6 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
+import time
 
 import io
 import six
@@ -26,7 +27,9 @@ def available():
 def _next_video_packet(container_iter):
     for packet in container_iter:
         if packet.stream.type == 'video':
-            return packet.decode()
+            decoded = packet.decode()
+            if len(decoded) > 0:
+                return decoded
 
     raise ValueError("Could not find any video packets.")
 
@@ -320,22 +323,32 @@ class PyAVReaderIndexed(FramesSequence):
         self._container = None
 
         with av.open(self.file, format=self.format) as container:
+            stream = [s for s in container.streams if s.type == 'video'][0]
+
             # Build a toc
             if toc is None:
-                self._toc = np.cumsum([len(packet.decode())
-                                       for packet in container.demux()
-                                       if packet.stream.type == 'video'])
+                self._packet_lengths = []
+                self._packet_ts = []
+                for packet in container.demux(stream):
+                    if packet.stream.type == 'video':
+                        decoded = packet.decode()
+                        if len(decoded) > 0:
+                            self._packet_lengths.append(len(decoded))
+                            self._packet_ts.append(decoded[0].pts)
+                self._toc = {
+                    'lengths': self._packet_lengths,
+                    'ts': self._packet_ts,
+                }
             else:
-                if isinstance(toc, list):
-                    self._toc = np.array(toc, dtype=np.int64)
-                else:
-                    self._toc = toc
-            self._len = self._toc[-1]
+                self._toc = toc
 
-            video_stream = [s for s in container.streams if s.type == 'video'][0]
+            self._toc_cumsum = np.cumsum(self._toc['lengths'])
+            self._len = self._toc_cumsum[-1]
+
             # PyAV always returns frames in color, and we make that
             # assumption in get_frame() later below, so 3 is hardcoded here:
-            self._im_sz = video_stream.height, video_stream.width, 3
+            self._im_sz = stream.height, stream.width, 3
+            self._time_base = stream.time_base
 
         self._load_fresh_file()
 
@@ -347,10 +360,13 @@ class PyAVReaderIndexed(FramesSequence):
             self.file.seek(0)
 
         self._container = av.open(self.file, format=self.format)
-        self._container_iter = self._container.demux()
-        self._current_packet = _next_video_packet(self._container_iter)
-        self._packet_cursor = 0
-        self._frame_cursor = 0
+        demux = self._container.demux(self._video_stream)
+        self._current_packet = _next_video_packet(demux)
+        self._current_packet_no = 0
+
+    @property
+    def _video_stream(self):
+        return [s for s in self._container.streams if s.type == 'video'][0]
 
     def __len__(self):
         return self._len
@@ -368,13 +384,13 @@ class PyAVReaderIndexed(FramesSequence):
 
     def get_frame(self, j):
         # Find the packet this frame is in.
-        packet_no = self._toc.searchsorted(j, side='right')
+        packet_no = self._toc_cumsum.searchsorted(j, side='right')
         self._seek_packet(packet_no)
         # Find the location of the frame within the packet.
         if packet_no == 0:
             loc = j
         else:
-            loc = j - self._toc[packet_no - 1]
+            loc = j - self._toc_cumsum[packet_no - 1]
         frame = self._current_packet[loc]  # av.VideoFrame
 
         return Frame(frame.to_ndarray(format='rgb24'), frame_no=j)
@@ -382,18 +398,18 @@ class PyAVReaderIndexed(FramesSequence):
     def _seek_packet(self, packet_no):
         """Advance through the container generator until we get the packet
         we want. Store that packet in selfpp._current_packet."""
-        if packet_no == self._packet_cursor:
-            # We have the right packet and it is already decoded.
-            return
-        if packet_no < self._packet_cursor:
-            # "Rewind." This is not really possible, so we load a fresh
-            # instance of the file object and then fast-forward.
-            self._load_fresh_file()
-        # Fast-forward if needed.
+        packet_ts = self._packet_ts[packet_no]
+        # Only seek when needed.
+        if (packet_no < self._current_packet_no
+                or packet_no > self._current_packet_no + 1):
+            self._container.seek(packet_ts, stream=self._video_stream)
 
-        while self._packet_cursor < packet_no:
-            self._current_packet = _next_video_packet(self._container_iter)
-            self._packet_cursor += 1
+        demux = self._container.demux(self._video_stream)
+        self._current_packet = _next_video_packet(demux)
+        while self._current_packet[0].pts < packet_ts:
+            self._current_packet = _next_video_packet(demux)
+
+        self._current_packet_no = packet_no
 
     @property
     def pixel_type(self):

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -400,7 +400,9 @@ class PyAVReaderIndexed(FramesSequence):
         we want. Store that packet in selfpp._current_packet."""
         packet_ts = self._packet_ts[packet_no]
         # Only seek when needed.
-        if (packet_no < self._current_packet_no
+        if packet_no == self._current_packet_no:
+            return
+        elif (packet_no < self._current_packet_no
                 or packet_no > self._current_packet_no + 1):
             self._container.seek(packet_ts, stream=self._video_stream)
 


### PR DESCRIPTION
Previously `PyAVReaderIndexed ` decoded every packet to seek to a specific packet. This PR tries to speed this up by instead indexing the timestamps of each packet and seeking to it using `container.seek()`.

This speeds up random access times by an order of magnitude. Sequential access time remains unchanged.

## Test Code
```python
test_reader = PyAVReaderIndexed(...)
inds = np.random.randint(low=0, high=len(test_reader), size=3)
print(test_reader)

def test():
    for i in inds:
        print(i)
        test_reader.get_frame(i)
    
%time test()
```

## Before
```
<Frames>
Source: /local1/kpar/spatialaudiogen/data/preproc-hr/cA88rNC2uuM-video.mp4
Length: 9061 frames
Frame Shape: (1080, 1920, 3)

673
7158
5975
CPU times: user 41.1 s, sys: 7.8 ms, total: 41.1 s
Wall time: 41.1 s
```

## After
```
<Frames>
Source: /local1/kpar/spatialaudiogen/data/preproc-hr/cA88rNC2uuM-video.mp4
Length: 9061 frames
Frame Shape: (1080, 1920, 3)

673
7158
5975
CPU times: user 1.78 s, sys: 8.01 ms, total: 1.79 s
Wall time: 1.78 s
```