### PR TITLE
Compatibility with Jpype 0.8

### DIFF
--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -1,6 +1,7 @@
 from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
+from distutils.version import LooseVersion
 import numpy as np
 
 from pims.base_frames import FramesSequence, FramesSequenceND
@@ -343,9 +344,15 @@ class BioformatsReader(FramesSequenceND):
         # Start java VM and initialize logger (globally)
         if not jpype.isJVMStarted():
             loci_path = _find_jar()
+            # If we can turn off string auto-conversion, do so,
+            # since this is the recommended practice.
+            if LooseVersion(jpype.__version__) >= LooseVersion('0.7.0'):
+                startJVM_kwargs = {'convertStrings': False}
+            else:
+                startJVM_kwargs = {}
             jpype.startJVM(jpype.getDefaultJVMPath(), '-ea',
                            '-Djava.class.path=' + loci_path,
-                           '-Xmx' + java_memory, convertStrings=False)
+                           '-Xmx' + java_memory, **startJVM_kwargs)
             log4j = jpype.JPackage('org.apache.log4j')
             log4j.BasicConfigurator.configure()
             log4j_logger = log4j.Logger.getRootLogger()

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -92,13 +92,6 @@ def _download_jar(version='5.7.0'):
     return path
 
 
-def _maybe_tostring(field):
-    if hasattr(field, 'toString'):
-        return str(field)
-    else:
-        return field
-
-
 def _jbytearr_stringbuffer(arr, dtype):
     # see https://github.com/originell/jpype/issues/71 and
     # https://github.com/originell/jpype/pull/73
@@ -152,11 +145,8 @@ class MetadataRetrieve(object):
             except TypeError:
                 pass
 
-            # check if it is already casted to a python type by jpype
-            if not hasattr(field, 'toString'):
-                return field
-            else:
-                field = str(field)
+            # Convert this Java value to a Python type
+            field = str(field)
 
             # convert to int or float if possible
             try:
@@ -563,17 +553,17 @@ class BioformatsReader(FramesSequenceND):
             result = {}
             while keys.hasMoreElements():
                 key = keys.nextElement()
-                result[key] = _maybe_tostring(hashtable.get(key))
+                result[key] = str(hashtable.get(key))
         elif form == 'list':
             result = []
             while keys.hasMoreElements():
                 key = keys.nextElement()
-                result.append(key + ': ' + _maybe_tostring(hashtable.get(key)))
+                result.append(key + ': ' + str(hashtable.get(key)))
         elif form == 'string':
             result = u''
             while keys.hasMoreElements():
                 key = keys.nextElement()
-                result += key + ': ' + _maybe_tostring(hashtable.get(key)) + '\n'
+                result += key + ': ' + str(hashtable.get(key)) + '\n'
         return result
 
     @property

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -93,7 +93,7 @@ def _download_jar(version='5.7.0'):
 
 def _maybe_tostring(field):
     if hasattr(field, 'toString'):
-        return field.toString()
+        return str(field)
     else:
         return field
 
@@ -155,7 +155,7 @@ class MetadataRetrieve(object):
             if not hasattr(field, 'toString'):
                 return field
             else:
-                field = field.toString()
+                field = str(field)
 
             # convert to int or float if possible
             try:
@@ -345,7 +345,7 @@ class BioformatsReader(FramesSequenceND):
             loci_path = _find_jar()
             jpype.startJVM(jpype.getDefaultJVMPath(), '-ea',
                            '-Djava.class.path=' + loci_path,
-                           '-Xmx' + java_memory)
+                           '-Xmx' + java_memory, convertStrings=False)
             log4j = jpype.JPackage('org.apache.log4j')
             log4j.BasicConfigurator.configure()
             log4j_logger = log4j.Logger.getRootLogger()

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -349,7 +349,7 @@ class BioformatsReader(FramesSequenceND):
             if LooseVersion(jpype.__version__) >= LooseVersion('0.7.0'):
                 startJVM_kwargs = {'convertStrings': False}
             else:
-                startJVM_kwargs = {}
+                startJVM_kwargs = {}  # convertStrings kwarg not supported for earlier jpype versions
             jpype.startJVM(jpype.getDefaultJVMPath(), '-ea',
                            '-Djava.class.path=' + loci_path,
                            '-Xmx' + java_memory, **startJVM_kwargs)

--- a/pims/tests/test_bioformats.py
+++ b/pims/tests/test_bioformats.py
@@ -539,7 +539,7 @@ class TestBioformatsMetadataND2(unittest.TestCase):
         metadata = self.v.get_metadata_raw('dict')
         assert_equal(metadata['ChannelCount'], '2')
         assert_equal(metadata['CH2ChannelDyeName'], '5-FAM/pH 9.0')
-        assert_equal(metadata['dCalibration'], '0.16780898323268245')
+        assert_almost_equal(float(metadata['dCalibration']), 0.16780898323268245)
 
     def test_metadata_tags(self):
         self.v = self.klass(self.filename, meta=True)


### PR DESCRIPTION
As noted in #330 and explained in the [Jpype change log](https://jpype.readthedocs.io/en/latest/CHANGELOG.html), starting with v0.7 it's recommended to use `str` to explicitly obtain Python strings from Java objects. Starting with v0.8, the old behavior will stop working unless an option is specified.

This PR makes `bioformats.py` compliant with the new string conversion convention, and for Jpype versions ≥ 0.7 it explicitly turns on the new convention. However the code is also compatible with earlier versions of Jpype.

Since I don't know much about `bioformats.py`, it would be great if someone else could test and/or review this code. It just needs to be merged before Jpype version 0.8 is released, but I'd like to get it into the PIMS v0.5 release.

Note that #330 is about an *incompatibility* with Jpype 0.7, which I cannot reproduce—maybe it was for PIMS v0.4.1. In any case, this PR addresses the underlying cause and closes #330. 