### PR TITLE
DEP: Pin bioformats at 6.x

### DIFF
--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -55,7 +55,7 @@ def _find_jar():
     return download_jar()
 
 
-def download_jar(version='6.5'):
+def download_jar(version='6'):
     """ Downloads the bioformats distribution of given version. """
     from six.moves.urllib.request import urlopen
     import hashlib


### PR DESCRIPTION
This implements @joshmoore 's suggestion in #301 to pin to the bioformats major version, 6.x .