### PR TITLE
Test with Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,9 @@ matrix:
       env: DEPS="numpy=1.8* slicerator tifffile" BUILD_DOCS=false
     - python: "2.7"
       env: DEPS="numpy slicerator pillow matplotlib scikit-image jinja2 av libtiff tifffile jpype1 moviepy imageio==2.4.1" BUILD_DOCS=false
-    - python: "3.6"
+    - python: "3.8"
       env: DEPS="numpy slicerator tifffile" BUILD_DOCS=false
-    - python: "3.6"
+    - python: "3.8"
       env: DEPS="numpy slicerator pillow matplotlib scikit-image jinja2 av tifffile libtiff jpype1 ipython sphinx sphinx_rtd_theme numpydoc moviepy imageio imageio-ffmpeg" BUILD_DOCS=true
 
 install:


### PR DESCRIPTION
The Python version in Travis had been pinned to 3.6. Our Python 3 environments, especially the last one, are meant to keep up with a typical fresh install of e.g. Anaconda.

The new environment I proposed in #358 would need to be updated accordingly.