### PR TITLE
BLD: Fix deprecated use of pypandoc in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,8 +10,8 @@ except IOError:
     descr = ''
 
 try:
-    from pypandoc import convert
-    descr = convert(descr, 'rst', format='md')
+    from pypandoc import convert_text
+    descr = convert_text(descr, 'rst', format='md')
 except ImportError:
     pass
 


### PR DESCRIPTION
This PR is not appropriate for v0.5 or maybe even v0.6. It fixes a deprecated call to `pypandoc` when converting the README.

```
setup.py:14: DeprecationWarning: Due to possible ambiguity, 'convert()' is deprecated. Use 'convert_file()'  or 'convert_text()'.
  descr = convert(descr, 'rst', format='md')
```

`convert_text()` has been available [since pypandoc v1.3.3](https://github.com/bebraw/pypandoc/commit/c57d131bd3584b9cce30b14ae33418163139fc15) in 2016. Still, we should be slow to merge this PR because it will break PIMS for anyone with an older version installed.