### PR TITLE
Remove fallback path to deprecated skimage.external.tifffile

### DIFF
--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -22,10 +22,7 @@ except ImportError:
 try:
     import tifffile
 except ImportError:
-    try:
-        from skimage.external import tifffile
-    except ImportError:
-        tifffile = None
+    tifffile = None
 
 
 def libtiff_available():


### PR DESCRIPTION
Closes https://github.com/soft-matter/pims/issues/356

As of October 2019 `scikit-image` no longer vendors `tifffile`, so this fallback path to the deprecated `skimage.external.tifffile` will always fail from `skikit-image` version 0.17 onwards.