### PR TITLE
Extending ImageSequence reader when only imageio (but not skimage/matplotlib) is installed

### DIFF
--- a/pims/image_reader.py
+++ b/pims/image_reader.py
@@ -25,7 +25,10 @@ except ImportError:
                  "in your script.)")
         warnings.warn(RuntimeWarning(ski_preferred))
     except ImportError:
-        imread = None
+        try:
+            from imageio import imread
+        except ImportError:
+            imread = None
 
 
 class ImageReader(FramesSequence):

--- a/pims/image_reader.py
+++ b/pims/image_reader.py
@@ -12,21 +12,22 @@ try:
     from skimage.io import imread
 except ImportError:
     try:
-        from matplotlib.pyplot import imread
-        # imread() works differently between scikit-image and matplotlib.
-        # We don't require users to have scikit-image, 
-        # but if we fall back to matplotlib, make sure the user 
-        # is aware of the consequences.
-        ski_preferred = ("PIMS image_reader.py could not find scikit-image. "
-                 "Falling back to matplotlib's imread(), which uses floats "
-                 "instead of integers. This may break your scripts. \n"
-                 "(To ignore this warning, include the line "
-                 '"warnings.simplefilter("ignore", RuntimeWarning)" '
-                 "in your script.)")
-        warnings.warn(RuntimeWarning(ski_preferred))
+        from imageio import imread
     except ImportError:
         try:
-            from imageio import imread
+            from matplotlib.pyplot import imread
+            # imread() works differently between scikit-image and matplotlib.
+            # We don't require users to have scikit-image,
+            # but if we fall back to matplotlib, make sure the user
+            # is aware of the consequences.
+            ski_preferred = ("PIMS image_reader.py could not find either "
+                    "scikit-image or imageio installed. "
+                    "Falling back to matplotlib's imread(), which uses floats "
+                    "instead of integers. This may break your scripts. \n"
+                    "(To ignore this warning, include the line "
+                    '"warnings.simplefilter("ignore", RuntimeWarning)" '
+                    "in your script.)")
+            warnings.warn(RuntimeWarning(ski_preferred))
         except ImportError:
             imread = None
 

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -29,7 +29,10 @@ except ImportError:
     try:
         from matplotlib.pyplot import imread
     except ImportError:
-        imread = None
+        try:
+            from imageio import imread
+        except ImportError:
+            imread = None
 
 
 class ImageSequence(FramesSequence):

--- a/pims/image_sequence.py
+++ b/pims/image_sequence.py
@@ -27,10 +27,10 @@ try:
     has_skimage = True
 except ImportError:
     try:
-        from matplotlib.pyplot import imread
+        from imageio import imread
     except ImportError:
         try:
-            from imageio import imread
+            from matplotlib.pyplot import imread
         except ImportError:
             imread = None
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -62,6 +62,17 @@ def _skip_if_no_skimage():
         raise nose.SkipTest('skimage not installed. Skipping.')
 
 
+def _skip_if_no_skimage_or_matplotlib():
+    try:
+        import skimage
+    except ImportError:
+        try:
+            import matplotlib
+        except ImportError:
+            raise nose.SkipTest('Test requires either matplotlib or'
+                                ' scikit-image. Skipping.')
+
+
 def _skip_if_no_PIL():
     import pims.tiff_stack
     if not pims.tiff_stack.PIL_available():

--- a/pims/tests/test_imseq.py
+++ b/pims/tests/test_imseq.py
@@ -13,7 +13,8 @@ import pims
 
 from pims.tests.test_common import (_image_series,
                                     clean_dummy_png, save_dummy_png,
-                                    _skip_if_no_skimage, _skip_if_no_imread)
+                                    _skip_if_no_skimage, _skip_if_no_imread,
+                                    _skip_if_no_skimage_or_matplotlib)
 
 path, _ = os.path.split(os.path.abspath(__file__))
 path = os.path.join(path, 'data')
@@ -107,7 +108,7 @@ class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
 
 class TestImageSequenceNaturalSorting(_image_series, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
+        _skip_if_no_skimage_or_matplotlib()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F1.png', 'T76S3F20.png',
                           'T76S3F3.png', 'T76S3F4.png',


### PR DESCRIPTION
Closes https://github.com/soft-matter/pims/issues/363

Adds a fallback path to imageio imread for `pims/image_sequence.py`

This is a "nice to have" extension of the current capabilities, aimed at allowing a lightweight minimal-ish set of pims dependencies that can cover most of the basic use cases (eg `tifffile` and `imageio`) without requiring more heavyweight dependencies like `scikit-image`/`matplotlib` are also installed.


