### PR TITLE
added frame_no to propagate_attrs

### DIFF
--- a/pims/base_frames.py
+++ b/pims/base_frames.py
@@ -90,7 +90,7 @@ class FramesSequence(FramesStream):
     Must be finite length.
 
     """
-    propagate_attrs = ['frame_shape', 'pixel_type']
+    propagate_attrs = ['frame_shape', 'pixel_type', 'frame_no']
 
     def __getitem__(self, key):
         """__getitem__ is handled by Slicerator. In all pims readers, the data


### PR DESCRIPTION
Fixes issue #368. This allows to propagate the `frame_no` of images in an image sequence, when the sequence is processed through a pipeline.