### PR TITLE
Fix frame number generation in `pyav_reader._gen_frames`

### DIFF
--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -59,7 +59,7 @@ def _gen_frames(demuxer, time_base, frame_rate=1., first_pts=0):
                     "Unable to read video: frames contain no timestamps. "
                     "Please use PyAVReaderIndexed.")
             t = (timestamp - first_pts) * time_base
-            i = int(t * frame_rate)
+            i = int(round(t * frame_rate))
             yield WrapPyAvFrame(frame, frame_no=i,
                                 metadata=dict(timestamp=timestamp, t=float(t)))
 


### PR DESCRIPTION
`pyav_reader._gen_frames` sometimes yields frame objects with incorrect frame numbers due to incorrect rounding.
Fixed by using `round` rather than `int`.
This has resulted in `PyAVTimedReader.get_frame` returning frame objects whose `frame_no` field has a different frame than the value passed to `get_frame`.
I was able to confirm this on a video file and verify that `PyAVTimedReader` and `PyAVIndexedReader` return different frames when randomly seeking. Furthermore, converting the video to a sequence of PNGs using ffmpeg and reading those agrees with `PyAVIndexedReader` but not `PyAVTimedReader`. This fix addresses this, resulting in `PyAVTimedReader` returning frame consistency with the others.
I may be able to release the video file for testing, but will have to check.
