### PR TITLE
Fix for issue 374, image with invalid datetime tag

### DIFF
--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -1,7 +1,10 @@
 import os
 from datetime import datetime
 import itertools
+import warnings
+
 import numpy as np
+
 from pims.frame import Frame
 
 try:
@@ -143,8 +146,10 @@ class TiffStack_tifffile(FramesSequence):
             if key == 'DateTime':
                 try:
                     md[key] = _tiff_datetime(md[key])
-                except Exception:
-                    pass
+                except ValueError:
+                    warnings.warn(
+                        "DateTime tiff tag could not be parsed correctly:" + \
+                        str(md[key]))
         return md
 
     @property

--- a/pims/tiff_stack.py
+++ b/pims/tiff_stack.py
@@ -141,7 +141,10 @@ class TiffStack_tifffile(FramesSequence):
             except UnicodeDecodeError:
                 md[key] = ''
             if key == 'DateTime':
-                md[key] = _tiff_datetime(md[key])
+                try:
+                    md[key] = _tiff_datetime(md[key])
+                except Exception:
+                    pass
         return md
 
     @property


### PR DESCRIPTION
Closes https://github.com/soft-matter/pims/issues/374

Using [this test image](https://github.com/jrussell25/data-sharing/blob/master/Pos001_S001_t21_z4_ch01.tif), you can now do this:
```python
import pims
img = pims.open('Pos001_S001_t21_z4_ch01.tif')
img.get_frame(0)  # no error
```