### PR TITLE
fix: Configure conda to use local .conda directory

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ USER pims
 # Set up the initial conda environment
 COPY --chown=pims:pims environment.yml /src/environment.yml
 WORKDIR /src
+RUN conda config --prepend envs_dirs $HOME/.conda/envs
+RUN conda config --prepend pkgs_dirs $HOME/.conda/pkgs
 RUN conda env create -f environment.yml \
     && conda clean -tipsy
 

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -361,7 +361,7 @@ class BioformatsReader(FramesSequenceND):
         # patch for issue with ND2 files and the Chunkmap implemented in 5.4.0
         # See https://github.com/openmicroscopy/bioformats/issues/2955
         # circumventing the reserved keyword 'in'
-        mo = getattr(loci.formats, 'in').DynamicMetadataOptions()
+        mo = getattr(loci.formats, 'in_').DynamicMetadataOptions()
         mo.set('nativend2.chunkmap', 'False')  # Format Bool as String
         self.rdr.setMetadataOptions(mo)
 


### PR DESCRIPTION
`conda create` creates the $HOME/.conda directory but does
not prepend it to conda config. Closes #377