### PR TITLE
FIX: Docker and test errors related to conda, imageio_ffmpeg, and loci.formats

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ USER pims
 # Set up the initial conda environment
 COPY --chown=pims:pims environment.yml /src/environment.yml
 WORKDIR /src
+RUN conda config --prepend envs_dirs $HOME/.conda/envs
+RUN conda config --prepend pkgs_dirs $HOME/.conda/pkgs
 RUN conda env create -f environment.yml \
     && conda clean -tipsy
 

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -361,7 +361,11 @@ class BioformatsReader(FramesSequenceND):
         # patch for issue with ND2 files and the Chunkmap implemented in 5.4.0
         # See https://github.com/openmicroscopy/bioformats/issues/2955
         # circumventing the reserved keyword 'in'
-        mo = getattr(loci.formats, 'in_').DynamicMetadataOptions()
+        try:
+            mo = getattr(loci.formats, 'in').DynamicMetadataOptions()
+        except AttributeError:
+            # Attribute name conflict causes mangling of `in` to `in_`
+            mo = getattr(loci.formats, 'in_').DynamicMetadataOptions()
         mo.set('nativend2.chunkmap', 'False')  # Format Bool as String
         self.rdr.setMetadataOptions(mo)
 

--- a/pims/bioformats.py
+++ b/pims/bioformats.py
@@ -361,7 +361,7 @@ class BioformatsReader(FramesSequenceND):
         # patch for issue with ND2 files and the Chunkmap implemented in 5.4.0
         # See https://github.com/openmicroscopy/bioformats/issues/2955
         # circumventing the reserved keyword 'in'
-        mo = getattr(loci.formats, 'in').DynamicMetadataOptions()
+        mo = getattr(loci.formats, 'in_').DynamicMetadataOptions()
         mo.set('nativend2.chunkmap', 'False')  # Format Bool as String
         self.rdr.setMetadataOptions(mo)
 

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -13,11 +13,11 @@ except ImportError:
     imageio = None
 try:
     import imageio_ffmpeg
+    try:
+        imageio_ffmpeg.get_ffmpeg_exe()
+    except RuntimeError:
+        imageio_ffmpeg = None
 except ImportError:
-    imageio_ffmpeg = None
-try:
-    imageio_ffmpeg.get_ffmpeg_exe()
-except RuntimeError:
     imageio_ffmpeg = None
 
 

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -15,6 +15,10 @@ try:
     import imageio_ffmpeg
 except ImportError:
     imageio_ffmpeg = None
+try:
+    imageio_ffmpeg.get_ffmpeg_exe()
+except RuntimeError:
+    imageio_ffmpeg = None
 
 
 def available():


### PR DESCRIPTION
Atrribute name conflict mangling causes `loci.formats.in` to be renamed `loci.formats.in_`. Added try/except logic to use `in_` if `in` fails with `AttributeError`.

`pims.imageio_reader` tests for the presence of ffmpeg executable by catching `ImportError` when importing `imageio_ffmpeg`. However, import of `imageio_ffmpeg` succeeds even when ffmpeg executable is not present. Added a call to `imageio_ffmpeg.get_ffmpeg_exe` to check if ffmpeg executable is present.

`conda create` creates the `$HOME/.conda` directory but does not prepend it to conda config. This might be an upstream bug in miniconda, but easily worked around by explicitly prepending local `env_dirs` and `pkg_dirs` in Dockerfile (see https://github.com/ContinuumIO/docker-images/issues/151#issuecomment-642603686 ).

Closes #377 and #379 .
