### PR TITLE
Drop dependency on nose for tests; fix numpy and python deprecations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
   # Append the conda-forge channel, instead of adding it. See:
   # https://github.com/conda-forge/conda-forge.github.io/issues/232)
   - conda config --append channels conda-forge
-  - conda create -n testenv --yes $DEPS nose python=$TRAVIS_PYTHON_VERSION
+  - conda create -n testenv --yes $DEPS python=$TRAVIS_PYTHON_VERSION
   - source activate testenv
   # only install pip if there are pip dependencies
   # - |
@@ -42,7 +42,7 @@ before_install:
   - export PATH=/home/travis/mc/bin:$PATH
 
 script:
-    - nosetests --nologcapture
+    - python -munittest
     # Doc Build needs: pillow matplotlib ipython sphinx sphinx_rtd_theme numpydoc
     - if [ $BUILD_DOCS == true ]; then make html --directory=./doc; fi
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@
 ##
 ##    docker build -t pims .
 ##    docker run -ti --rm pims
-##    nosetests --nologcapture
+##    python -munittest
 ##
 
 FROM continuumio/miniconda3

--- a/doc/source/pipelines.rst
+++ b/doc/source/pipelines.rst
@@ -135,7 +135,7 @@ unnamed lambda function in a single line:
 
 .. ipython:: python
 
-   processed_video = pims.pipeline(lambda x: x.astype(np.float))(video)
+   processed_video = pims.pipeline(lambda x: x.astype(float))(video)
    processed_frame = processed_video[0]
    print(processed_frame.shape)
 

--- a/environment.yml
+++ b/environment.yml
@@ -20,5 +20,4 @@ dependencies:
 - moviepy
 - imageio
 - imageio-ffmpeg
-- nose
 - openjdk

--- a/pims/cine.py
+++ b/pims/cine.py
@@ -26,7 +26,7 @@ import datetime
 import hashlib
 import sys
 import warnings
-from collections import Iterable
+from collections.abc import Iterable
 
 __all__ = ('Cine', )
 

--- a/pims/display.py
+++ b/pims/display.py
@@ -716,7 +716,7 @@ def plot_to_frame(fig, width=512, close_fig=False, fig_size_inches=None,
             fig.savefig(buf, format='rgba', dpi=dpi)
             buf.seek(0)
             buf_shape = (int(height_in * dpi), int(width_in * dpi), 4)
-            image = np.fromstring(buf.read(),
+            image = np.frombuffer(buf.read(),
                                   dtype='uint8').reshape(*buf_shape)
 
     if close_fig:

--- a/pims/ffmpeg_reader.py
+++ b/pims/ffmpeg_reader.py
@@ -216,7 +216,7 @@ class FFmpegVideoReader(FramesSequence):
         self.data_buffer.seek(self._stride*j)
         s = self.data_buffer.read(self._stride)
         w, h = self._size
-        result = np.fromstring(s,
+        result = np.frombuffer(s,
             dtype='uint8').reshape((h, w, self.depth))
         return Frame(result, frame_no=j)
 

--- a/pims/process.py
+++ b/pims/process.py
@@ -73,7 +73,7 @@ class crop(Pipeline):
         # We have to know the frame shape that is returned by the reader.
         try:  # In case the reader is a FramesSequence, there is an attribute
             shape = reader.frame_shape
-            first_frame = np.empty(shape, dtype=np.bool)
+            first_frame = np.empty(shape, dtype=bool)
         except AttributeError:
             first_frame = reader[0]
             shape = first_frame.shape

--- a/pims/spe_stack.py
+++ b/pims/spe_stack.py
@@ -174,7 +174,7 @@ class SpeStack(FramesSequence):
             if cnt == 1:
                 #for convenience, if the array contains only one single entry,
                 #return this entry itself.
-                v = np.asscalar(v)
+                v = v.item()
             self.metadata[name] = v
 
         ### Some metadata is "special", deal with it

--- a/pims/tests/test_bioformats.py
+++ b/pims/tests/test_bioformats.py
@@ -8,7 +8,6 @@ import six
 
 import os
 import unittest
-import nose
 import numpy as np
 from numpy.testing import (assert_equal, assert_almost_equal, assert_allclose)
 
@@ -20,7 +19,7 @@ path = os.path.join(path, 'data')
 
 def _skip_if_no_bioformats():
     if not pims.bioformats.available():
-        raise nose.SkipTest('JPype is not installed. Skipping.')
+        raise unittest.SkipTest('JPype is not installed. Skipping.')
 
 
 def assert_image_equal(actual, expected):
@@ -187,7 +186,7 @@ class TestBioformatsMOV(_image_series, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'wtembryo.mov')
@@ -212,7 +211,7 @@ class TestBioformatsIPW(_image_series, _image_stack, _image_multichannel,
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'mitosis-test.ipw')
@@ -236,7 +235,7 @@ class TestBioformatsDM3(_image_single, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'dnasample1.dm3')
@@ -259,7 +258,7 @@ class TestBioformatsLSM(_image_series, _image_stack, _image_multichannel,
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', '2chZT.lsm')
@@ -284,7 +283,7 @@ class TestBioformatsAndorTiff(_image_series, _image_stack, _image_multichannel,
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'MF-2CH-Z-T.tif')
@@ -309,7 +308,7 @@ class TestBioformatsOlympusTiff(_image_series, _image_stack, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', '10-31 E1.tif')
@@ -337,7 +336,7 @@ class TestBioformatsLIFseries1(_image_single, _image_stack, _image_multichannel,
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'mouse-kidney.lif')
@@ -367,7 +366,7 @@ class TestBioformatsLIFseries2(_image_single, _image_stack, _image_multichannel,
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'mouse-kidney.lif')
@@ -390,7 +389,7 @@ class TestBioformatsIPL(_image_single, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'Blend_Final.IPL')
@@ -411,7 +410,7 @@ class TestBioformatsSEQ(_image_single, _image_stack, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'HEART.SEQ')
@@ -435,7 +434,7 @@ class TestBioformatsLEI(_image_single, _image_stack, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'leica_stack.lei')
@@ -460,7 +459,7 @@ class TestBioformatsICS(_image_single, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'qdna1.ics')
@@ -483,7 +482,7 @@ class TestBioformatsZPO(_image_stack, _image_multichannel, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_bioformats()
         if not os.path.isfile(self.filename):
-            raise nose.SkipTest('File missing. Skipping.')
+            raise unittest.SkipTest('File missing. Skipping.')
 
     def setUp(self):
         self.filename = os.path.join(path, 'bioformats', 'KEVIN2-3.zpo')
@@ -547,5 +546,5 @@ class TestBioformatsMetadataND2(unittest.TestCase):
         assert 'PixelsPhysicalSizeX' in fields
 
 if __name__ == '__main__':
-    nose.runmodule(argv=[__file__, '-vvs'],
+    unittest.runmodule(argv=[__file__, '-vvs'],
                    exit=False)

--- a/pims/tests/test_cine.py
+++ b/pims/tests/test_cine.py
@@ -3,7 +3,6 @@
 import os
 from datetime import datetime
 import unittest
-import nose
 import numpy as np
 import pims
 import pims.cine
@@ -33,8 +32,8 @@ class test_legacy_cine_sample(_common_cine_sample_tests, unittest.TestCase):
         self.sample_filename = os.path.join(tests_path, 'data',
                                             'cine_legacy.cine')
         if not os.path.exists(self.sample_filename):
-            raise nose.SkipTest('Legacy sample cine file not found. '
-                                'Skipping.')
+            raise unittest.SkipTest('Legacy sample cine file not found. '
+                                    'Skipping.')
 
         self.options = {}
         super(test_legacy_cine_sample, self).setUp()
@@ -51,8 +50,8 @@ class test_new_cine_sample(_common_cine_sample_tests, unittest.TestCase):
         self.sample_filename = os.path.join(tests_path, 'data',
                                             'cine_781.cine')
         if not os.path.exists(self.sample_filename):
-            raise nose.SkipTest('Newer sample cine file not found. '
-                                'Skipping.')
+            raise unittest.SkipTest('Newer sample cine file not found. '
+                                    'Skipping.')
         self.options = {}
         super(test_new_cine_sample, self).setUp()
 

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -9,10 +9,8 @@ import random
 import types
 import unittest
 import pickle
-import nose
 import numpy as np
 from numpy.testing import (assert_equal, assert_allclose)
-from nose.tools import assert_true
 import pims
 
 path, _ = os.path.split(os.path.abspath(__file__))
@@ -22,50 +20,50 @@ path = os.path.join(path, 'data')
 def _skip_if_no_PyAV():
     import pims.pyav_reader
     if not pims.pyav_reader.available():
-        raise nose.SkipTest('PyAV not found. Skipping.')
+        raise unittest.SkipTest('PyAV not found. Skipping.')
 
 
 def _skip_if_no_MoviePy():
     import pims.moviepy_reader
     if not pims.moviepy_reader.available():
-        raise nose.SkipTest('MoviePy not found. Skipping.')
+        raise unittest.SkipTest('MoviePy not found. Skipping.')
 
 
 def _skip_if_no_ImageIO_ffmpeg():
     import pims.imageio_reader
     if not pims.imageio_reader.ffmpeg_available():
-        raise nose.SkipTest('ImageIO and ffmpeg not found. Skipping.')
+        raise unittest.SkipTest('ImageIO and ffmpeg not found. Skipping.')
 
 
 def _skip_if_no_libtiff():
     import pims.tiff_stack
     if not pims.tiff_stack.libtiff_available():
-        raise nose.SkipTest('libtiff not installed. Skipping.')
+        raise unittest.SkipTest('libtiff not installed. Skipping.')
 
 
 def _skip_if_no_tifffile():
     import pims.tiff_stack
     if not pims.tiff_stack.tifffile_available():
-        raise nose.SkipTest('tifffile not installed. Skipping.')
+        raise unittest.SkipTest('tifffile not installed. Skipping.')
 
 
 def _skip_if_no_imread():
     if pims.image_sequence.imread is None:
-        raise nose.SkipTest('ImageSequence requires either matplotlib or'
-                            ' scikit-image. Skipping.')
+        raise unittest.SkipTest('ImageSequence requires either matplotlib or'
+                                ' scikit-image. Skipping.')
 
 
 def _skip_if_no_skimage():
     try:
         import skimage
     except ImportError:
-        raise nose.SkipTest('skimage not installed. Skipping.')
+        raise unittest.SkipTest('skimage not installed. Skipping.')
 
 
 def _skip_if_no_PIL():
     import pims.tiff_stack
     if not pims.tiff_stack.PIL_available():
-        raise nose.SkipTest('PIL/Pillow not installed. Skipping.')
+        raise unittest.SkipTest('PIL/Pillow not installed. Skipping.')
 
 
 def assert_image_equal(actual, expected):
@@ -254,7 +252,7 @@ class TestRecursiveSlicing(unittest.TestCase):
         compare_slice_to_list(slice1, list('bcdefghij'))
         slice2 = slice1[(i for i in range(2,5))]
         assert_letters_equal(slice2, list('def'))
-        assert_true(isinstance(slice2, types.GeneratorType))
+        self.assertTrue(isinstance(slice2, types.GeneratorType))
 
 def _rescale(img):
     return (img - img.min()) / img.ptp()
@@ -604,5 +602,4 @@ class TestOpenFiles(unittest.TestCase):
         pims.open(os.path.join(path, 'stuck.tif'))
 
 if __name__ == '__main__':
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    unittest.main()

--- a/pims/tests/test_display.py
+++ b/pims/tests/test_display.py
@@ -2,7 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-import nose
+import unittest
 import os
 import functools
 import numpy as np
@@ -10,7 +10,6 @@ import pims
 from numpy.testing import assert_array_equal
 from pims import plot_to_frame, plots_to_frame
 from pims.display import export_moviepy, export_pyav
-from nose.tools import assert_true, assert_equal, assert_less
 from .test_common import _skip_if_no_MoviePy, _skip_if_no_PyAV, path
 
 import unittest
@@ -25,7 +24,7 @@ except ImportError:
 
 def _skip_if_no_mpl():
     if plt is None:
-        raise nose.SkipTest('Matplotlib not installed. Skipping.')
+        raise unittest.SkipTest('Matplotlib not installed. Skipping.')
 
 
 class TestPlotToFrame(unittest.TestCase):
@@ -55,58 +54,59 @@ class TestPlotToFrame(unittest.TestCase):
 
     def test_ax_to_frame(self):
         frame = plot_to_frame(self.axes[0])
-        assert_equal(frame.shape, (384, 512, 4))
+        self.assertEqual(frame.shape, (384, 512, 4))
 
     def test_plot_to_frame(self):
         frame = plot_to_frame(self.figures[0])
-        assert_equal(frame.shape, (384, 512, 4))
+        self.assertEqual(frame.shape, (384, 512, 4))
 
     def test_axes_to_frame(self):
         frame = plots_to_frame(self.axes)
-        assert_equal(frame.shape, (10, 384, 512, 4))
+        self.assertEqual(frame.shape, (10, 384, 512, 4))
 
     def test_plots_to_frame(self):
         frame = plots_to_frame(self.figures)
-        assert_equal(frame.shape, (10, 384, 512, 4))
+        self.assertEqual(frame.shape, (10, 384, 512, 4))
 
     def test_plot_width(self):
         width = np.random.randint(100, 1000)
         frame = plot_to_frame(self.figures[0], width)
-        assert_equal(frame.shape[1], width)
+        self.assertEqual(frame.shape[1], width)
 
     def test_plot_tight(self):
         fig = self.figures[0]
         fig.set_tight_layout(False)  # default to standard
-        assert_equal(plot_to_frame(fig).shape[:2], (384, 512))
-        assert_less(plot_to_frame(fig, bbox_inches='tight').shape[:2], (384, 512))
-        assert_equal(plot_to_frame(fig).shape[:2], (384, 512))
+        self.assertEqual(plot_to_frame(fig).shape[:2], (384, 512))
+        self.assertLess(
+            plot_to_frame(fig, bbox_inches='tight').shape[:2], (384, 512))
+        self.assertEqual(plot_to_frame(fig).shape[:2], (384, 512))
 
         fig.set_tight_layout(True)  # default to tight
-        assert_less(plot_to_frame(fig).shape[:2], (384, 512))
-        assert_equal(plot_to_frame(fig, bbox_inches='standard').shape[:2],
-                     (384, 512))
-        assert_less(plot_to_frame(fig).shape[:2], (384, 512))
+        self.assertLess(plot_to_frame(fig).shape[:2], (384, 512))
+        self.assertEqual(
+            plot_to_frame(fig, bbox_inches='standard').shape[:2], (384, 512))
+        self.assertLess(plot_to_frame(fig).shape[:2], (384, 512))
 
     def test_plots_tight(self):
         frame = plots_to_frame(self.figures, bbox_inches='tight')
-        assert_less(frame.shape[1:3], (384, 512))
+        self.assertLess(frame.shape[1:3], (384, 512))
 
     def test_plot_resize(self):
         frame = plot_to_frame(self.figures[0], fig_size_inches=(4, 4))
-        assert_equal(frame.shape, (512, 512, 4))
+        self.assertEqual(frame.shape, (512, 512, 4))
 
     def test_plots_resize(self):
         frame = plots_to_frame(self.figures, fig_size_inches=(4, 4))
-        assert_equal(frame.shape, (10, 512, 512, 4))
+        self.assertEqual(frame.shape, (10, 512, 512, 4))
 
     def test_plots_width(self):
         width = np.random.randint(100, 1000)
         frame = plots_to_frame(self.figures, width)
-        assert_equal(frame.shape[2], width)
+        self.assertEqual(frame.shape[2], width)
 
     def test_plots_from_generator(self):
         frame = plots_to_frame(iter(self.figures))
-        assert_equal(frame.shape, (10, 384, 512, 4))
+        self.assertEqual(frame.shape, (10, 384, 512, 4))
 
 
 class ExportCommon(object):
@@ -141,7 +141,7 @@ class ExportCommon(object):
                          quality=0.01)
         compressed_size = int(os.path.getsize(self.tempfile))
 
-        assert_less(compressed_size, lossless_size)
+        self.assertLess(compressed_size, lossless_size)
 
     def test_quality_mpeg4(self):
         self.export_func(self.sequence, self.tempfile, codec='mpeg4',
@@ -152,7 +152,7 @@ class ExportCommon(object):
                          quality=5)
         compressed_size = int(os.path.getsize(self.tempfile))
 
-        assert_less(compressed_size, lossless_size)
+        self.assertLess(compressed_size, lossless_size)
 
     def test_quality_h264(self):
         self.export_func(self.sequence, self.tempfile, codec='libx264',
@@ -163,7 +163,7 @@ class ExportCommon(object):
                          quality=23)
         compressed_size = int(os.path.getsize(self.tempfile))
 
-        assert_less(compressed_size, lossless_size)
+        self.assertLess(compressed_size, lossless_size)
 
     def test_rgba_h264(self):
         """Remove alpha channel."""
@@ -174,8 +174,8 @@ class ExportCommon(object):
                          pixel_format='bgr24')
         sequence_rgba_stripped = self.sequence_rgba[:, :, :, :3]
         with pims.open(self.tempfile) as reader:
-            assert_equal(len(reader), self.expected_len)
-            assert_equal(reader.frame_shape, self.expected_shape)
+            self.assertEqual(len(reader), self.expected_len)
+            self.assertEqual(reader.frame_shape, self.expected_shape)
             for a, b in zip(sequence_rgba_stripped, reader):
                 assert_array_equal(a, b)
 
@@ -184,8 +184,8 @@ class ExportCommon(object):
         self.export_func(self.sequence, self.tempfile, codec='rawvideo',
                          pixel_format='bgr24')
         with pims.open(self.tempfile) as reader:
-            assert_equal(len(reader), self.expected_len)
-            assert_equal(reader.frame_shape, self.expected_shape)
+            self.assertEqual(len(reader), self.expected_len)
+            self.assertEqual(reader.frame_shape, self.expected_shape)
             for a, b in zip(self.sequence, reader):
                 assert_array_equal(a, b)
 
@@ -196,8 +196,8 @@ class ExportCommon(object):
                          self.tempfile, codec='rawvideo',
                          pixel_format='bgr24')
         with pims.open(self.tempfile) as reader:
-            assert_equal(len(reader), self.expected_len)
-            assert_equal(reader.frame_shape, self.expected_shape)
+            self.assertEqual(len(reader), self.expected_len)
+            self.assertEqual(reader.frame_shape, self.expected_shape)
             for a, b in zip(self.sequence, reader):
                 assert_array_equal(a, b)
 

--- a/pims/tests/test_factories.py
+++ b/pims/tests/test_factories.py
@@ -1,6 +1,6 @@
 import numpy as np
 import unittest
-from numpy.testing.utils import assert_array_equal
+from numpy.testing import assert_array_equal
 from pims.image_sequence import customize_image_sequence
 
 

--- a/pims/tests/test_factories.py
+++ b/pims/tests/test_factories.py
@@ -1,15 +1,17 @@
 import numpy as np
-from nose.tools import assert_equal
+import unittest
 from numpy.testing.utils import assert_array_equal
 from pims.image_sequence import customize_image_sequence
 
+
+@unittest.FunctionTestCase
 def test_customize_image_sequence():
     dummy = lambda filename, **kwargs: np.zeros((1, 1))
     reader = customize_image_sequence(dummy)
     result = reader(['a', 'b', 'c'])
     actual_len = len(result)
-    assert_equal(actual_len, 3)
+    assert actual_len == 3
     for frame in result:
         assert_array_equal(frame, np.zeros((1, 1)))
     reader2 = customize_image_sequence(dummy, 'my_name')
-    assert_equal(reader2.__name__, 'my_name')
+    assert reader2.__name__ == 'my_name'

--- a/pims/tests/test_frame.py
+++ b/pims/tests/test_frame.py
@@ -2,43 +2,45 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import six
-import nose
+import unittest
 import numpy as np
 from pims.frame import Frame
-from nose.tools import assert_true, assert_equal
 
 
 def _skip_if_no_PIL():
     try:
         from PIL import Image
     except ImportError:
-        raise nose.SkipTest('PIL/Pillow not installed. Skipping.')
+        raise unittest.SkipTest('PIL/Pillow not installed. Skipping.')
 
 
 def _skip_if_no_jinja2():
     try:
         import jinja2
     except ImportError:
-        raise nose.SkipTest('Jinja2 not installed. Skipping.')
+        raise unittest.SkipTest('Jinja2 not installed. Skipping.')
 
 
+@unittest.FunctionTestCase
 def test_scalar_casting():
     tt = Frame(np.ones((5, 3)), frame_no=42)
     sum1 = tt.sum()
-    assert_true(np.isscalar(sum1))
+    assert np.isscalar(sum1)
     sum2 = tt.sum(keepdims=True)
-    assert_equal(sum2.ndim, 2)
-    assert_equal(sum2.frame_no, tt.frame_no)
+    assert sum2.ndim == 2
+    assert sum2.frame_no == tt.frame_no
 
 
+@unittest.FunctionTestCase
 def test_creation_md():
     md_dict = {'a': 1}
     frame_no = 42
     tt = Frame(np.ones((5, 3)), frame_no=frame_no, metadata=md_dict)
-    assert_equal(tt.metadata, md_dict)
-    assert_equal(tt.frame_no, frame_no)
+    assert tt.metadata == md_dict
+    assert tt.frame_no == frame_no
 
 
+@unittest.FunctionTestCase
 def test_repr_html_():
     _skip_if_no_PIL()
     _skip_if_no_jinja2()
@@ -47,23 +49,26 @@ def test_repr_html_():
     Frame(10000*np.ones((50, 50), dtype=np.uint16))._repr_html_()
 
 
+@unittest.FunctionTestCase
 def test_copy():
     md_dict = {'a': 1}
     frame_no = 42
     tt_base = Frame(np.ones((5, 3)), frame_no=frame_no, metadata=md_dict)
     tt = Frame(tt_base)
-    assert_equal(tt.metadata, md_dict)
-    assert_equal(tt.frame_no, frame_no)
+    assert tt.metadata == md_dict
+    assert tt.frame_no == frame_no
 
 
+@unittest.FunctionTestCase
 def test_copy_override_frame():
     frame_no = 42
     tt_base = Frame(np.ones((5, 3)), frame_no=frame_no)
     frame_no_2 = 123
     tt = Frame(tt_base, frame_no=frame_no_2)
-    assert_equal(tt.frame_no, frame_no_2)
+    assert tt.frame_no == frame_no_2
 
 
+@unittest.FunctionTestCase
 def test_copy_update_md():
     frame_no = 42
     md_dict = {'a': 1}
@@ -76,7 +81,7 @@ def test_copy_update_md():
     target_dict.update(md_dict2)
     # print(target_dict)
     # print(tt.metadata)
-    assert_equal(tt.metadata, target_dict)
+    assert tt.metadata == target_dict
 
     tt2 = Frame(tt_base, frame_no=frame_no, metadata=md_dict3)
-    assert_equal(tt2.metadata, md_dict3)
+    assert tt2.metadata == md_dict3

--- a/pims/tests/test_multidimensional.py
+++ b/pims/tests/test_multidimensional.py
@@ -4,8 +4,6 @@ from __future__ import (absolute_import, division, print_function,
 import six
 
 import unittest
-import nose
-from nose.tools import assert_raises
 from itertools import chain, permutations
 import numpy as np
 from numpy.testing import assert_equal
@@ -126,11 +124,11 @@ class TestMultidimensional(unittest.TestCase):
         a = dict(self.v.default_coords)
         a['non_existing'] = 0
         # but assigning it again raises
-        with assert_raises(ValueError) as cm:
+        with self.assertRaises(ValueError) as cm:
             self.v.default_coords = a
 
         # changing an nonexisting item should raise
-        with assert_raises(ValueError) as cm:
+        with self.assertRaises(ValueError) as cm:
             self.v.default_coords['non_existing'] = 0
 
 
@@ -184,5 +182,4 @@ class TestFramesSequenceND(unittest.TestCase):
             assert_equal(reader[0].shape, [sizes[k] for k in bundle])
 
 if __name__ == '__main__':
-    nose.runmodule(argv=[__file__, '-vvs', '-x', '--pdb', '--pdb-failure'],
-                   exit=False)
+    unittest.main()

--- a/pims/tests/test_norpix.py
+++ b/pims/tests/test_norpix.py
@@ -38,7 +38,7 @@ class _common_norpix_sample_tests(object):
         hashes = set()  # Check that each frame is unique
         for i in range(len(s)):
             fr = s[i]
-            fhash = hash(np.array(fr).tostring())
+            fhash = hash(np.array(fr).tobytes())
             assert fhash not in hashes
             hashes.add(fhash)
 

--- a/pims/tests/test_norpix.py
+++ b/pims/tests/test_norpix.py
@@ -3,7 +3,6 @@
 import os
 from datetime import datetime
 import unittest
-import nose
 import numpy as np
 import pims
 import pims.norpix_reader
@@ -84,8 +83,8 @@ class test_norpix5_sample(_common_norpix_sample_tests, unittest.TestCase):
         self.sample_filename = os.path.join(tests_path, 'data',
                                             'sample_norpix5.seq')
         if not os.path.exists(self.sample_filename):
-            raise nose.SkipTest('(Large) Norpix v5 sample file not found. '
-                                'Skipping.')
+            raise unittest.SkipTest('(Large) Norpix v5 sample file not found. '
+                                    'Skipping.')
 
         self.options = {}
         super(test_norpix5_sample, self).setUp()

--- a/pims/tests/test_process.py
+++ b/pims/tests/test_process.py
@@ -5,7 +5,6 @@ import six
 
 import os
 import unittest
-import nose
 import numpy as np
 from numpy.testing import assert_equal
 from pims import FramesSequence, Frame

--- a/pims/tests/test_process.py
+++ b/pims/tests/test_process.py
@@ -17,7 +17,7 @@ class RandomReader(FramesSequence):
         self._dtype = dtype
         self._shape = shape
         data_shape = (length,) + shape
-        if np.issubdtype(self._dtype, np.float):
+        if np.issubdtype(self._dtype, float):
             self._data = np.random.random(data_shape).astype(self._dtype)
         else:
             self._data = np.random.randint(0, np.iinfo(self._dtype).max,


### PR DESCRIPTION
See https://github.com/soft-matter/trackpy/pull/588 for rationale of dropping nose.