### PR TITLE
Remove dependency on pypandoc in setup.py.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,13 +9,6 @@ try:
 except IOError:
     descr = ''
 
-try:
-    from pypandoc import convert
-    descr = convert(descr, 'rst', format='md')
-except ImportError:
-    pass
-
-
 setup_parameters = dict(
     name="PIMS",
     license="BSD-3-clause",
@@ -29,6 +22,8 @@ setup_parameters = dict(
     packages=['pims',
               'pims.utils',
               'pims.tests'],
-    long_description=descr)
+    long_description=descr,
+    long_description_content_type='text/markdown',
+)
 
 setup(**setup_parameters)


### PR DESCRIPTION
markdown is natively supported since setuptools 36.4.0 (2017), and
anyways that's only a version requirement for the person doing the
release, not for anyone else (older setuptools just ignore the kwarg
with a warning).

Closes https://github.com/soft-matter/pims/pull/361.