### PR TITLE
Add dependency on imageio; remove matplotlib-based reader.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,6 @@ Formats readable by pims include:
 
 PIMS is based on readers by:
 * [scikit-image](http://scikit-image.org/)
-* [matplotlib](http://matplotlib.org/)
 * [ffmpeg](https://www.ffmpeg.org/) and [PyAV](http://mikeboers.github.io/PyAV/) (video formats such as AVI, MOV)
 * [jpype](http://jpype.readthedocs.org/en/latest/) (interface with Bio-formats)
 * [Pillow](http://pillow.readthedocs.org/en/latest/) (improved TIFF support)

--- a/doc/source/image_sequence.rst
+++ b/doc/source/image_sequence.rst
@@ -41,6 +41,6 @@ popular formats like PNG, JPG, TIFF, and others. PIMS requires **one of
 the following** packages, in order of decreasing preference.
 
 * `scikit-image <http://scikit-image.org/>`_
-* `matplotlib <http://matplotlib.org/>`_
+* `imageio <https://imageio.github.io/>`_
 
 Scikit-image is installed with the PIMS conda package.

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -48,23 +48,11 @@ def _skip_if_no_tifffile():
         raise unittest.SkipTest('tifffile not installed. Skipping.')
 
 
-def _skip_if_no_imread():
-    if pims.image_sequence.imread is None:
-        raise unittest.SkipTest('ImageSequence requires either matplotlib or'
-                                ' scikit-image. Skipping.')
-
-
 def _skip_if_no_skimage():
     try:
         import skimage
     except ImportError:
         raise unittest.SkipTest('skimage not installed. Skipping.')
-
-
-def _skip_if_no_PIL():
-    import pims.tiff_stack
-    if not pims.tiff_stack.PIL_available():
-        raise unittest.SkipTest('PIL/Pillow not installed. Skipping.')
 
 
 def assert_image_equal(actual, expected):
@@ -183,7 +171,6 @@ def compare_slice_to_list(actual, expected):
 class TestRecursiveSlicing(unittest.TestCase):
 
     def setUp(self):
-        _skip_if_no_imread()
         class DemoReader(pims.ImageSequence):
             def imread(self, filename, **kwargs):
                 return np.array([[filename]])
@@ -382,7 +369,6 @@ class _image_series(_image_single):
 
 class TestImageReaderTIFF(_image_single, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
         self.filename = os.path.join(path, 'stuck.tif')
         self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
         self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
@@ -395,7 +381,6 @@ class TestImageReaderTIFF(_image_single, unittest.TestCase):
 
 class TestImageReaderPNG(_image_single, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
         self.klass = pims.ImageReader
         self.kwargs = dict()
         self.expected_shape = (10, 11)
@@ -408,7 +393,6 @@ class TestImageReaderPNG(_image_single, unittest.TestCase):
 
 class TestImageReaderND(_image_single, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
         self.klass = pims.ImageReaderND
         self.kwargs = dict()
         self.expected_shape = (10, 11, 3)
@@ -516,7 +500,6 @@ class TestTiffStack_pil(_tiff_image_series, unittest.TestCase):
         pass
 
     def setUp(self):
-        _skip_if_no_PIL()
         self.filename = os.path.join(path, 'stuck.tif')
         self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
         self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
@@ -572,9 +555,6 @@ class TestSpeStack(_image_series, unittest.TestCase):
 
 
 class TestOpenFiles(unittest.TestCase):
-    def setUp(self):
-        _skip_if_no_PIL()
-
     def test_open_png(self):
         self.filenames = ['dummy_png.png']
         shape = (10, 11)
@@ -583,7 +563,6 @@ class TestOpenFiles(unittest.TestCase):
         clean_dummy_png(path, self.filenames)
 
     def test_open_pngs(self):
-        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
                           'T76S3F00003.png', 'T76S3F00004.png',

--- a/pims/tests/test_frame.py
+++ b/pims/tests/test_frame.py
@@ -7,13 +7,6 @@ import numpy as np
 from pims.frame import Frame
 
 
-def _skip_if_no_PIL():
-    try:
-        from PIL import Image
-    except ImportError:
-        raise unittest.SkipTest('PIL/Pillow not installed. Skipping.')
-
-
 def _skip_if_no_jinja2():
     try:
         import jinja2
@@ -39,7 +32,6 @@ def test_creation_md():
 
 
 def test_repr_html_():
-    _skip_if_no_PIL()
     _skip_if_no_jinja2()
     # This confims a bugfix, where 16-bit images would raise
     # an error.

--- a/pims/tests/test_imseq.py
+++ b/pims/tests/test_imseq.py
@@ -13,7 +13,7 @@ import pims
 
 from pims.tests.test_common import (_image_series,
                                     clean_dummy_png, save_dummy_png,
-                                    _skip_if_no_skimage, _skip_if_no_imread)
+                                    _skip_if_no_skimage)
 
 path, _ = os.path.split(os.path.abspath(__file__))
 path = os.path.join(path, 'data')
@@ -83,7 +83,6 @@ class TestImageSequenceWithMPL(_image_series, unittest.TestCase):
 
 class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F00001.png', 'T76S3F00002.png',
                           'T76S3F00003.png', 'T76S3F00004.png',
@@ -107,7 +106,6 @@ class TestImageSequenceAcceptsList(_image_series, unittest.TestCase):
 
 class TestImageSequenceNaturalSorting(_image_series, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence')
         self.filenames = ['T76S3F1.png', 'T76S3F20.png',
                           'T76S3F3.png', 'T76S3F4.png',
@@ -150,7 +148,6 @@ class TestImageSequenceNaturalSorting(_image_series, unittest.TestCase):
 
 class ImageSequenceND(_image_series, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')
         self.filenames = ['file_t001_z001_c1.png',
                           'file_t001_z001_c2.png',
@@ -212,7 +209,6 @@ class ImageSequenceND(_image_series, unittest.TestCase):
 
 class ImageSequenceND_RGB(_image_series, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')
         self.filenames = ['file_t001_z001_c1.png',
                           'file_t001_z002_c1.png',
@@ -249,7 +245,6 @@ class ImageSequenceND_RGB(_image_series, unittest.TestCase):
 
 class ReaderSequence(_image_series, unittest.TestCase):
     def setUp(self):
-        _skip_if_no_imread()
         self.filepath = os.path.join(path, 'image_sequence3d')
         self.filenames = ['file001.png',
                           'file002.png',

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,12 @@ setup_parameters = dict(
     cmdclass=versioneer.get_cmdclass(),
     description="Python Image Sequence",
     author="PIMS Contributors",
-    install_requires=['slicerator>=0.9.8', 'six>=1.8', 'numpy>=1.19'],
+    install_requires=[
+        'imageio',
+        'numpy>=1.19',
+        'six>=1.8',
+        'slicerator>=0.9.8',
+    ],
     author_email="dallan@pha.jhu.edu",
     url="https://github.com/soft-matter/pims",
     packages=["pims", "pims.utils", "pims.tests"],


### PR DESCRIPTION
matplotlib's imread is now anyways a thin shim around pillow (a
dependency of matplotlib), so if you have matplotlib installed, you may
as well use imageio's imread: imageio is a smaller dependency, and has
more consistent behavior (it doesn't return pngs as floats).

imageio is also a dependency of scikit-image (since 0.15), so it seems
reasonable to directly depend on it instead.  For now, the scikit-image
reader was kept, as removing it (possibly in the future) would entail
removing support for the `plugin` kwarg, and thus an API break.
(See also https://github.com/soft-matter/pims/pull/273#discussion_r141855815.)