### PR TITLE
Update pyav_reader.py to make generator threadsafe

### DIFF
--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -27,6 +27,28 @@ def _next_video_packet(container_iter):
     raise ValueError("Could not find any video packets.")
 
 
+class threadsafe_iter:
+    """Takes an iterator/generator and makes it thread-safe by
+    serializing call to the `next` method of given iterator/generator.
+    """
+    def __init__(self, it):
+        self.it = it
+        self.lock = threading.Lock()
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        with self.lock:
+            return self.it.next()
+          
+def threadsafe_generator(f):
+    """A decorator that takes a generator function and makes it thread-safe.
+    """
+    def g(*a, **kw):
+        return threadsafe_iter(f(*a, **kw))
+    return g
+          
 class WrapPyAvFrame(object):
     def __init__(self, frame, frame_no, metadata=None):
         self.frame_no = frame_no
@@ -46,7 +68,7 @@ class WrapPyAvFrame(object):
                              frame_no=self.frame_no, metadata=self.metadata)
         return self.arr
 
-
+@threadsafe_generator
 def _gen_frames(demuxer, time_base, frame_rate=1., first_pts=0):
     for packet in demuxer:
         for frame in packet.decode():

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -41,7 +41,7 @@ class threadsafe_iter:
 
     def __next__(self):
         with self.lock:
-            return self.it.next()
+            return next(self.it)
           
 def threadsafe_generator(f):
     """A decorator that takes a generator function and makes it thread-safe.

--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -2,6 +2,7 @@ from __future__ import (absolute_import, division, print_function,
                         unicode_literals)
 
 import numpy as np
+import threading
 
 from pims.base_frames import FramesSequence
 from pims.frame import Frame


### PR DESCRIPTION
I had an issue where code using pyav_reader.py would randomly break and throw a "ValueError: Generator Already Executing Error"; the stack indicated that the function _gen_frames was the culprit; I added a function and a decorator (line for line copied from the sources below with one change, re-naming "next" to "__next__") that makes a non-threadsafe generator threadsafe. This resolved the issue on both Windows and Mac. I thought I'd send it over to you guys for your perusal! Thanks for the great package!

The original error message:  <img width="736" alt="Screen Shot 2021-08-28 at 3 40 56 PM" src="https://user-images.githubusercontent.com/26655008/131230507-e63fbad7-4503-4a13-ab73-babbf1146526.png">


Sources:
https://anandology.com/blog/using-iterators-and-generators/
https://stackoverflow.com/questions/41194726/python-generator-thread-safety-using-keras