### PR TITLE
AttributeError fix for issue #405

### DIFF
--- a/pims/pyav_reader.py
+++ b/pims/pyav_reader.py
@@ -226,7 +226,7 @@ class PyAVReaderTimed(FramesSequence):
         # the ffmpeg decode cache is flushed automatically
 
         timestamp = int(i / (self._frame_rate * self._stream.time_base))
-        self._stream.seek(timestamp + self._first_pts)
+        self._stream.container.seek(timestamp + self._first_pts)
 
         # check the first frame
         try:

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -429,7 +429,6 @@ class TestVideo_PyAV_indexed(_image_series, unittest.TestCase):
         self.expected_len = 480
 
 
-@pytest.mark.xfail
 class TestVideo_ImageIO(_image_series, unittest.TestCase):
     def check_skip(self):
         _skip_if_no_ImageIO_ffmpeg()


### PR DESCRIPTION
Hi,


We think this is the same error encountered in issue #405, and this patch should resolve it, at least for the case where `av.VideoStream` is the stream.  

On non-sequential seeks, the `get_frame()` method in the `PyAVReaderTimed` class calls `self._stream.seek`, but when the stream is an `av.VideoStream`, it doesn't find a `seek()` method.  Instead, the `seek()` method can be found at `av.VideoStream.container.seek()`.  This pull request just changes the line to `self._stream.container.seek`.  We tested that this patch worked well with dask_image, which uses `PyAVReaderTimed`.

Note that this is not the case for sequential frame retrieval, where the `get_frame()` method in the `PyAVReaderTimed` class avoids calling the seek method when the previous frame is already loaded.

This error can be recreated with the following:

Environment:
```
conda create --name testpims python=3.8
conda activate testpims
conda install -c conda-forge av
pip install pims
```

Python code:
```python
>>> import pims
>>> aa = pims.PyAVReaderTimed('video.avi')
>>> aa.get_frame(0) # no problem
>>> aa.get_frame(1) # no problem
>>> aa.get_frame(3) # error
File av\stream.pyx:124
AttributeError: seek
>>> aa.seek(10)   # error with any frame number
File av\stream.pyx:124
AttributeError: seek
```


Thanks for such a great package, and we hope you will check the fix works and integrate it into a pims release soon!

Best wishes,

Joeri, Lucas, and Nick