### PR TITLE
CI: pin back imageio for testing

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 codecov
 coverage
 flake8
+imageio <2.16.2   # to avoid warnings
 pytest
 sphinx
 scikit-image


### PR DESCRIPTION
2.16.2 introduces warnings for using the v2 api

This is a stop-gap to get tests passing (to do a release!).  We can leave user to pin back if they want to avoid the warnings as well.