### PR TITLE
Fix for issue 413 re: video files (do not know how to deal with infinite readers)

### DIFF
--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -60,6 +60,9 @@ class ImageIOReader(FramesSequenceND):
         self.reader = imageio.get_reader(filename, **kwargs)
         self.filename = filename
         self._len = self.reader.get_length()
+        # fallback to count_frames, for newer imageio versions
+        if self._len == float("inf"):
+            self._len = self.reader.count_frames()
         try:
             int(self._len)
         except OverflowError:
@@ -67,10 +70,6 @@ class ImageIOReader(FramesSequenceND):
             raise NotImplementedError(
                 "Do not know how to deal with infinite readers"
                 )
-
-        # fallback to count_frames, for newer imageio versions
-        if self._len == float("inf"):
-            self._len = self.reader.count_frames()
 
         first_frame = self.get_frame_2D(t=0)
         self._shape = first_frame.shape


### PR DESCRIPTION
Closes https://github.com/soft-matter/pims/issues/413

It looks like [this change](https://github.com/soft-matter/pims/commit/4cd240d51a17563e355f9091648f5fbddaeae9e1) has caused a problem where some(most?) video files that could previously be opened with pims ImageIOReader now hit an error.

The fix seems pretty simple, I think we just move the fallback [block of code](https://github.com/soft-matter/pims/blob/c49dc7a965560bc2ef375d3a807da58bc0618863/pims/imageio_reader.py#L71-L73) up above the try/except statement. That way, if the infinite frame value can be replaced with something sensible, it will be before the infinite value causes an error.

I've tried the fix out on a single mp4 file, and it seemed to work well.