### PR TITLE
Fix ImageIOReader for images with channels and reordered axes

### DIFF
--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -72,20 +72,21 @@ class ImageIOReader(FramesSequenceND):
                 )
 
         first_frame = self.get_frame_2D(t=0)
-        self._shape = first_frame.shape
         self._dtype = first_frame.dtype
 
-        self._setup_axes()
+        self._setup_axes(first_frame.shape)
         self._register_get_frame(self.get_frame_2D, 'yx')
 
-    def _setup_axes(self):
+    def _setup_axes(self, frame_shape):
         """Setup the xyctz axes, iterate over t axis by default
 
         """
-        if self._shape[1] > 0:
-            self._init_axis('x', self._shape[1])
-        if self._shape[0] > 0:
-            self._init_axis('y', self._shape[0])
+        if frame_shape[1] > 0:
+            self._init_axis('x', frame_shape[1])
+        if frame_shape[0] > 0:
+            self._init_axis('y', frame_shape[0])
+        if len(frame_shape) > 2:
+            self._init_axis('c', frame_shape[3])
         if self._len > 0:
             self._init_axis('t', self._len)
 
@@ -137,10 +138,6 @@ class ImageIOReader(FramesSequenceND):
     @property
     def frame_rate(self):
         return self.get_metadata()['fps']
-
-    @property
-    def frame_shape(self):
-        return self._shape
 
     @property
     def pixel_type(self):


### PR DESCRIPTION
This fixes the ImageIOReader to recognize channels and report them correctl in `images.sizes`. Also, the `frame_shape` implementation is removed, since it did not account for reordered axes via `bundle_axes`. It would be great if a @soft-matter maintainer could add a test-case, e.g. using `scifio-test.jp2` from `https://samples.scif.io/test-jpeg2000.zip`.

The current behavior looks like this:
```python
>>> import pims
>>> = pims.open("scifio-test.jp2")
>>> p.shape  # correct
(1, 500, 500, 3)
>>> p[0].shape  # also correct
(500, 500, 3)
>>> p.sizes  # c missing!
{'x': 500, 'y': 500, 't': 1}
>>> p.bundle_axes="cxy"
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/jonathan/.cache/pypoetry/virtualenvs/webknossos--lLCZL8U-py3.9/lib/python3.9/site-packages/pims/base_frames.py", line 524, in bundle_axes
    raise ValueError("axes %r do not exist" % invalid)
ValueError: axes ['c'] do not exist
# and even after setting up the c axis, the shape is not corrected:
>>> p._init_axis("c", 3)
>>> p.bundle_axes="cyx"
>>> p.shape  # should be 1,3,500,500
(1, 500, 500, 3)
```

