### PR TITLE
Don't emit warnings that duplicate exceptions on opening failure.

### DIFF
--- a/pims/api.py
+++ b/pims/api.py
@@ -195,15 +195,14 @@ def open(sequence, **kwargs):
                 return 10
         return sorted(handlers, key=priority, reverse=True)
 
-    exceptions = ''
+    messages = []
     for handler in sort_on_priority(eligible_handlers):
         try:
             return handler(sequence, **kwargs)
         except Exception as e:
-            message = '{0} errored: {1}'.format(str(handler), str(e))
-            warn(message)
-            exceptions += message + '\n'
-    raise UnknownFormatError("All handlers returned exceptions:\n" + exceptions)
+            messages.append('{} errored: {}'.format(str(handler), str(e)))
+    raise UnknownFormatError(
+        "All handlers returned exceptions:\n" + "\n".join(messages))
 
 
 class UnknownFormatError(Exception):


### PR DESCRIPTION
The error messages will already be displayed in the exception, so no need to emit them as warnings too.  Moreover, warnings are somewhat more annoying to suppress than exceptions.

(One *could* consider still emitting the warnings if e.g. the first reader failed but the second one succeeds, but I'm not sure it's worth the trouble.)

(CI failure is due to skimage-latest-release not being compatible yet with numpy-latest-release; I can put up a PR pinning numpy if you'd like.)