### PR TITLE
MNT: Drop support for libtiff

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,6 @@ PIMS is based on readers by:
 * [ffmpeg](https://www.ffmpeg.org/) and [PyAV](http://mikeboers.github.io/PyAV/) (video formats such as AVI, MOV)
 * [jpype](http://jpype.readthedocs.org/en/latest/) (interface with Bio-formats)
 * [Pillow](http://pillow.readthedocs.org/en/latest/) (improved TIFF support)
-* [libtiff](https://code.google.com/p/pylibtiff/) (alternative TIFF support)
 * [tifffile](https://pypi.org/project/tifffile/) (alterative TIFF support)
 * [pims_nd2](https://github.com/soft-matter/pims_nd2) (improved Nikon .nd2 support)
 * [imageio](https://imageio.github.io) (a multi-purpose reader package that

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -29,8 +29,6 @@ Depending on what file formats you want to read, you will also need:
    microscopy formats)
 -  `Pillow <http://pillow.readthedocs.org/en/latest/>`__ (improved TIFF
    support)
--  `libtiff <https://code.google.com/p/pylibtiff/>`__ (alternative TIFF
-   support)
 -  `tifffile <http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html>`__
    (alterative TIFF support)
 -  `imageio <https://imageio.github.io/>`__ (a multi-purpose reader package that

--- a/doc/source/tiff_stack.rst
+++ b/doc/source/tiff_stack.rst
@@ -18,15 +18,14 @@ Dependencies
 There are several Python packages for reading TIFFs. Our default reader, built
 around `Christoph Gohlke's tifffile.py <http://www.lfd.uci.edu/~gohlke/code/tifffile.py.html>`__,
 handles all the formats we have personally encountered. But we have
-alternative TIFF readers built around Pillow (see above) and libtiff.
+an alternative TIFF reader built around Pillow (see above).
 To use a specific reader, use
-``TiffStack_tifffile``, ``TiffStack_libtiff``, or ``TiffStack_pil``, which
+``TiffStack_tifffile`` or ``TiffStack_pil``, which
 depend, respectively, on the packages below. The "default" reader,
 ``TiffStack`` is an alias. At import time, it is pointed to the first
 reader for which the required package is installed.
 
 * `tifffile <https://pypi.python.org/pypi/tifffile>`_
-* `pylibtiff <https://pypi.python.org/pypi/libtiff>`_
 * `Pillow <https://pillow.readthedocs.org/>`_ or `PIL <http://www.pythonware.com/products/pil/>`_
 
 Tifffile is installed with the PIMS conda package.

--- a/environment.yml
+++ b/environment.yml
@@ -11,7 +11,6 @@ dependencies:
 - jinja2
 - av
 - tifffile
-- libtiff
 - jpype1
 - ipython
 - sphinx

--- a/examples/loading video frames.ipynb
+++ b/examples/loading video frames.ipynb
@@ -219,7 +219,7 @@
       "\n",
       "``ImageSequence`` relies only on ``numpy`` and ``scipy``, which are required dependencies of ``mr``, so it works\n",
       "out of the box. ``Video`` needs [OpenCV](http://opencv.org/), which includes the Python module ``cv2``.\n",
-      "``TiffStack`` needs ``libtiff``.\n",
+      "``TiffStack`` needs ``tifffile`` or ``Pillow``.\n",
       "\n",
       "Once these dependencies are in place, ``Video`` and ``TiffStack`` work in the same way as ``ImageSequence``."
      ]

--- a/pims/api.py
+++ b/pims/api.py
@@ -73,26 +73,21 @@ if Video is None:
     Video = not_available("PyAV, MoviePy, or ImageIO")
 
 import pims.tiff_stack
-from pims.tiff_stack import (TiffStack_pil, TiffStack_libtiff,
-                                TiffStack_tifffile)
+from pims.tiff_stack import (TiffStack_pil, TiffStack_tifffile)
 # First, check if each individual class is available
 # and drop in placeholders as needed.
 if not pims.tiff_stack.tifffile_available():
     TiffStack_tiffile = not_available("tifffile")
-if not pims.tiff_stack.libtiff_available():
-    TiffStack_libtiff = not_available("libtiff")
 if not pims.tiff_stack.PIL_available():
     TiffStack_pil = not_available("PIL or Pillow")
 # Second, decide which class to assign to the
 # TiffStack alias.
 if pims.tiff_stack.tifffile_available():
     TiffStack = TiffStack_tifffile
-elif pims.tiff_stack.libtiff_available():
-    TiffStack = TiffStack_libtiff
 elif pims.tiff_stack.PIL_available():
     TiffStack = TiffStack_pil
 else:
-    TiffStack = not_available("tifffile, libtiff, or PIL/Pillow")
+    TiffStack = not_available("tifffile or PIL/Pillow")
 
 
 try:

--- a/pims/tests/test_common.py
+++ b/pims/tests/test_common.py
@@ -32,12 +32,6 @@ def _skip_if_no_ImageIO_ffmpeg():
         raise unittest.SkipTest('ImageIO and ffmpeg not found. Skipping.')
 
 
-def _skip_if_no_libtiff():
-    import pims.tiff_stack
-    if not pims.tiff_stack.libtiff_available():
-        raise unittest.SkipTest('libtiff not installed. Skipping.')
-
-
 def _skip_if_no_tifffile():
     import pims.tiff_stack
     if not pims.tiff_stack.tifffile_available():
@@ -475,22 +469,6 @@ class _tiff_image_series(_image_series):
         with open(pkl_path, 'rb') as p:
             d = pickle.load(p)
         assert_equal(m, d)
-
-
-class TestTiffStack_libtiff(_tiff_image_series, unittest.TestCase):
-    def check_skip(self):
-        _skip_if_no_libtiff()
-
-    def setUp(self):
-        _skip_if_no_libtiff()
-        self.filename = os.path.join(path, 'stuck.tif')
-        self.frame0 = np.load(os.path.join(path, 'stuck_frame0.npy'))
-        self.frame1 = np.load(os.path.join(path, 'stuck_frame1.npy'))
-        self.klass = pims.TiffStack_libtiff
-        self.kwargs = dict()
-        self.v = self.klass(self.filename, **self.kwargs)
-        self.expected_shape = (512, 512)
-        self.expected_len = 5
 
 
 class TestTiffStack_pil(_tiff_image_series, unittest.TestCase):


### PR DESCRIPTION
As suggested by @anntzer in #437 , this drops support for `libtiff` in the interests of simplifying maintenance. For purposes of pims and its users, we're not aware of any functionality in `libtiff` that is not provided by `tifffile` and/or Pillow.