### PR TITLE
FIX: Close files in case of reader failure

### DIFF
--- a/pims/cine.py
+++ b/pims/cine.py
@@ -336,7 +336,6 @@ class Cine(FramesSequence):
     For a .chd file, this class only reads the header, not the images.
     
     """
-    # TODO: Unit tests using a small sample cine file.
     @classmethod
     def class_exts(cls):
         return {'cine'} | super(Cine, cls).class_exts()
@@ -742,6 +741,10 @@ class Cine(FramesSequence):
 
     def close(self):
         self.f.close()
+
+    def __del__(self):
+        if hasattr(self, 'f'):
+            self.f.close()
 
     def __unicode__(self):
         return self.filename

--- a/pims/imageio_reader.py
+++ b/pims/imageio_reader.py
@@ -149,3 +149,7 @@ class ImageIOReader(FramesSequenceND):
     def close(self):
         self.reader.close()
         super().close()
+
+    def __del__(self):
+        if hasattr(self, 'reader'):
+            self.reader.close()

--- a/pims/norpix_reader.py
+++ b/pims/norpix_reader.py
@@ -256,6 +256,10 @@ class NorpixSeq(FramesSequence):
     def close(self):
         self._file.close()
 
+    def __del__(self):
+        if hasattr(self, '_file'):
+            self._file.close()
+
     def __repr__(self):
         return """<Frames>
 Source: {filename}


### PR DESCRIPTION
This fixes #416 by ensuring that files opened by the NorPix and cine readers are closed promptly if there's a problem during initialization (e.g. invalid file format).