### PR TITLE
FIX: Natural sort order - handle spaces

### DIFF
--- a/pims/utils/sort.py
+++ b/pims/utils/sort.py
@@ -3,12 +3,12 @@ import re
 __all__ = ["natural_keys"]
 
 
-def _atoi(text):
+def _atoi(text: str):
     return int(text) if text.isdigit() else text
 
 
-def natural_keys(text):
-    """Sort list of string in a human way.
+def natural_keys(text: str):
+    """Natural sort order function for strings.
     See: http://stackoverflow.com/questions/5967500/how-to-correctly-sort-a-string-with-a-number-
     inside
     Examples
@@ -18,4 +18,4 @@ def natural_keys(text):
     >>> print(alist)
     ['something1', 'something2', 'something12', 'something17']
     """
-    return [_atoi(c) for c in re.split(r'(\d+)', text)]
+    return [_atoi(c) for c in re.split(r'(\d+)', text.replace(' ', ''))]

--- a/pims/utils/tests/test_sort.py
+++ b/pims/utils/tests/test_sort.py
@@ -1,7 +1,13 @@
+import unittest
+
 from pims.utils.sort import natural_keys
 
 
-def test_natural_keys():
-    alist = ["something1", "something12", "something17", "something2"]
-    alist.sort(key=natural_keys)
-    assert alist == ['something1', 'something2', 'something12', 'something17']
+class TestNaturalSort(unittest.TestCase):
+    def setUp(self):
+        pass
+
+    def test_natural_keys(self):
+        alist = ["something1", "something12", "something17", "something2"]
+        alist.sort(key=natural_keys)
+        assert alist == ['something1', 'something2', 'something12', 'something17']

--- a/pims/utils/tests/test_sort.py
+++ b/pims/utils/tests/test_sort.py
@@ -11,3 +11,25 @@ class TestNaturalSort(unittest.TestCase):
         alist = ["something1", "something12", "something17", "something2"]
         alist.sort(key=natural_keys)
         assert alist == ['something1', 'something2', 'something12', 'something17']
+
+    def test_natural_keys_with_spaces(self):
+        paths = [
+            '/data/meh/img-   19.tiff',
+            '/data/meh/img-   181.tiff',
+            '/data/meh/img-   20.tiff',
+            '/data/meh/img-    0.tiff',
+            '/data/meh/img-    1.tiff',
+            '/data/meh/img-    2.tiff',
+        ]
+
+        paths.sort(key=natural_keys)
+
+        assert paths == [
+            '/data/meh/img-    0.tiff',
+            '/data/meh/img-    1.tiff',
+            '/data/meh/img-    2.tiff',
+            '/data/meh/img-   19.tiff',
+            '/data/meh/img-   20.tiff',
+            '/data/meh/img-   181.tiff',
+
+        ]


### PR DESCRIPTION
A bug fix to amend issue #309 - sort.natural can now handle spaces in the path. 

Additionally:
- Edited docstring.
- Added type hints.
- Added new test.
- Edited existing test to use unittest. 