### PR TITLE
Update imageio link

### DIFF
--- a/doc/source/image_sequence.rst
+++ b/doc/source/image_sequence.rst
@@ -47,6 +47,6 @@ popular formats like PNG, JPG, TIFF, and others. PIMS requires **one of
 the following** packages, in order of decreasing preference.
 
 * `scikit-image <http://scikit-image.org/>`_
-* `imageio <https://imageio.github.io/>`_
+* `imageio <https://imageio.readthedocs.io/en/stable/>`_
 
 Scikit-image is installed with the PIMS conda package.


### PR DESCRIPTION
The `imageio` link redirects, so I've replaced it with where it ends up.